### PR TITLE
v1.2.0 - Adds Calendar Cleaner Changes

### DIFF
--- a/changes.md
+++ b/changes.md
@@ -13,4 +13,5 @@
 - Adds several progress bars during various slower processing sections.
 - Adds helper method to generate diagnostic data file.
   - Diag file contains a observation file manifest including compressed fits file names.
+- Adds short term scheduler to processed calendar meta data.
 - Adds tests for all of these changes.

--- a/changes.md
+++ b/changes.md
@@ -17,6 +17,6 @@
 - Adds short term scheduler to processed calendar meta data.
 - Adds override for PRI_CMD_DIR -> 9.
 - Adds ability to convert det method 2 to 1 and adds pre-defined RA/DEC for the single ROI for observations that have max_num_rois = 1.
-- Adds ability to clean bad symbols (like "+") and other unsupported words (like "nan").
+- Adds ability to clean bad symbols (like "+" and spaces " ") and other unsupported words (like "nan") in target IDs.
 - Adds data volume exploration jupyter notebook to docs/
 - Adds tests for all of these changes.

--- a/changes.md
+++ b/changes.md
@@ -8,4 +8,5 @@
 - Adds warnings if single NIRDA or VISDA data file exceeds payload limits.
 - Adds dependence on NIRDA reset1 for VITL settling time. These parameters are all adjustable.
 - Adds helper that renumbers both visits and sequencies to fix any misnumbering after merges.
+- Adds log file to track changes, info, and warnings raised by the short term scheduler.
 - Adds tests for all of these changes.

--- a/changes.md
+++ b/changes.md
@@ -7,3 +7,4 @@
 - Adds ability to merge back-to-back observations of the same target.
 - Adds ability to override payload parameters set by original long-term calendar on a per-priority type basis.
 - Adds warnings if single NIRDA or VISDA data file exceeds payload limits.
+- Adds dependence on NIRDA reset1 for VITL settling time. These parameters are all adjustable.

--- a/changes.md
+++ b/changes.md
@@ -2,3 +2,5 @@
 
 - Adds NIRDA and VISDA classes which contain accurate and up to date parameters to perform timing and data volume calculations.
   - Adds tests for these new classes.
+- Adds overhead class which accounts for pre- and post- overhead timings for both VISDA and NIRDA
+- Adds baseline short-term calendar runner script to docs/

--- a/changes.md
+++ b/changes.md
@@ -18,4 +18,5 @@
 - Adds override for PRI_CMD_DIR -> 9.
 - Adds ability to convert det method 2 to 1 and adds pre-defined RA/DEC for the single ROI for observations that have max_num_rois = 1.
 - Adds ability to clean bad symbols (like "+") and other unsupported words (like "nan").
+- Adds data volume exploration jupyter notebook to docs/
 - Adds tests for all of these changes.

--- a/changes.md
+++ b/changes.md
@@ -15,4 +15,5 @@
 - Adds helper method to generate diagnostic data file.
   - Diag file contains a observation file manifest including compressed fits file names.
 - Adds short term scheduler to processed calendar meta data.
+- Adds override for PRI_CMD_DIR -> 9.
 - Adds tests for all of these changes.

--- a/changes.md
+++ b/changes.md
@@ -1,7 +1,7 @@
 ## v1.2.0 (2026-xxx)
 
 - Adds NIRDA and VISDA classes which contain accurate and up to date parameters to perform timing and data volume calculations.
-- Adds overhead class which accounts for pre- and post- overhead timings for both VISDA and NIRDA
+- Adds overhead class which accounts for pre- and post- overhead timings for both VISDA and NIRDA.
 - Adds baseline short-term calendar runner script to docs/
 - Adds ability to merge back-to-back observations of the same target.
 - Adds ability to override payload parameters set by original long-term calendar on a per-priority type basis.
@@ -11,4 +11,6 @@
 - Adds log file to track changes, info, and warnings raised by the short term scheduler.
 - Fixes minute-by-minute parsing to improve processing time.
 - Adds several progress bars during various slower processing sections.
+- Adds helper method to generate diagnostic data file.
+  - Diag file contains a observation file manifest including compressed fits file names.
 - Adds tests for all of these changes.

--- a/changes.md
+++ b/changes.md
@@ -17,4 +17,5 @@
 - Adds short term scheduler to processed calendar meta data.
 - Adds override for PRI_CMD_DIR -> 9.
 - Adds ability to convert det method 2 to 1 and adds pre-defined RA/DEC for the single ROI for observations that have max_num_rois = 1.
+- Adds ability to clean bad symbols (like "+") and other unsupported words (like "nan").
 - Adds tests for all of these changes.

--- a/changes.md
+++ b/changes.md
@@ -16,4 +16,5 @@
   - Diag file contains a observation file manifest including compressed fits file names.
 - Adds short term scheduler to processed calendar meta data.
 - Adds override for PRI_CMD_DIR -> 9.
+- Adds ability to convert det method 2 to 1 and adds pre-defined RA/DEC for the single ROI for observations that have max_num_rois = 1.
 - Adds tests for all of these changes.

--- a/changes.md
+++ b/changes.md
@@ -1,0 +1,4 @@
+## v1.2.0 (2026-xxx)
+
+- Adds NIRDA and VISDA classes which contain accurate and up to date parameters to perform timing and data volume calculations.
+  - Adds tests for these new classes.

--- a/changes.md
+++ b/changes.md
@@ -4,3 +4,4 @@
   - Adds tests for these new classes.
 - Adds overhead class which accounts for pre- and post- overhead timings for both VISDA and NIRDA
 - Adds baseline short-term calendar runner script to docs/
+- Adds ability to merge back-to-back observations of the same target

--- a/changes.md
+++ b/changes.md
@@ -1,10 +1,11 @@
 ## v1.2.0 (2026-xxx)
 
 - Adds NIRDA and VISDA classes which contain accurate and up to date parameters to perform timing and data volume calculations.
-  - Adds tests for these new classes.
 - Adds overhead class which accounts for pre- and post- overhead timings for both VISDA and NIRDA
 - Adds baseline short-term calendar runner script to docs/
 - Adds ability to merge back-to-back observations of the same target.
 - Adds ability to override payload parameters set by original long-term calendar on a per-priority type basis.
 - Adds warnings if single NIRDA or VISDA data file exceeds payload limits.
 - Adds dependence on NIRDA reset1 for VITL settling time. These parameters are all adjustable.
+- Adds helper that renumbers both visits and sequencies to fix any misnumbering after merges.
+- Adds tests for all of these changes.

--- a/changes.md
+++ b/changes.md
@@ -4,5 +4,6 @@
   - Adds tests for these new classes.
 - Adds overhead class which accounts for pre- and post- overhead timings for both VISDA and NIRDA
 - Adds baseline short-term calendar runner script to docs/
-- Adds ability to merge back-to-back observations of the same target
+- Adds ability to merge back-to-back observations of the same target.
 - Adds ability to override payload parameters set by original long-term calendar on a per-priority type basis.
+- Adds warnings if single NIRDA or VISDA data file exceeds payload limits.

--- a/changes.md
+++ b/changes.md
@@ -10,4 +10,5 @@
 - Adds helper that renumbers both visits and sequencies to fix any misnumbering after merges.
 - Adds log file to track changes, info, and warnings raised by the short term scheduler.
 - Fixes minute-by-minute parsing to improve processing time.
+- Adds several progress bars during various slower processing sections.
 - Adds tests for all of these changes.

--- a/changes.md
+++ b/changes.md
@@ -5,6 +5,7 @@
 - Adds baseline short-term calendar runner script to docs/
 - Adds ability to merge back-to-back observations of the same target.
 - Adds ability to override payload parameters set by original long-term calendar on a per-priority type basis.
+  - Overrides can be taken from user provided dict or from the visda/nirda class defaults.
 - Adds warnings if single NIRDA or VISDA data file exceeds payload limits.
 - Adds dependence on NIRDA reset1 for VITL settling time. These parameters are all adjustable.
 - Adds helper that renumbers both visits and sequencies to fix any misnumbering after merges.

--- a/changes.md
+++ b/changes.md
@@ -5,3 +5,4 @@
 - Adds overhead class which accounts for pre- and post- overhead timings for both VISDA and NIRDA
 - Adds baseline short-term calendar runner script to docs/
 - Adds ability to merge back-to-back observations of the same target
+- Adds ability to override payload parameters set by original long-term calendar on a per-priority type basis.

--- a/changes.md
+++ b/changes.md
@@ -9,4 +9,5 @@
 - Adds dependence on NIRDA reset1 for VITL settling time. These parameters are all adjustable.
 - Adds helper that renumbers both visits and sequencies to fix any misnumbering after merges.
 - Adds log file to track changes, info, and warnings raised by the short term scheduler.
+- Fixes minute-by-minute parsing to improve processing time.
 - Adds tests for all of these changes.

--- a/docs/data_volumes_and_integrations.ipynb
+++ b/docs/data_volumes_and_integrations.ipynb
@@ -1,0 +1,380 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "id": "a1b2c301",
+   "metadata": {},
+   "source": [
+    "# Data volumes and integrations\n",
+    "\n",
+    "Shows how to use `NirdaData`, `VisdaData`, and `OverheadTiming` directly —\n",
+    "without running through the full scheduler pipeline — to compute integration\n",
+    "counts and data volumes for a given observation window.\n",
+    "\n",
+    "The three classes work independently of any science calendar:\n",
+    "\n",
+    "- **`NirdaData`** — detector timing and data volume for one NIRDA observation\n",
+    "- **`VisdaData`** — detector timing and data volume for one VISDA observation\n",
+    "- **`OverheadTiming`** — MOC command-sequence overhead consumed before and after each observation"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 1,
+   "id": "b2c3d402",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import numpy as np\n",
+    "import matplotlib.pyplot as plt\n",
+    "from astropy import units as u\n",
+    "from astropy.time import Time\n",
+    "\n",
+    "from shortschedule import NirdaData\n",
+    "from shortschedule.visda import VisdaData\n",
+    "from shortschedule.overhead import OverheadTiming"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "c3d4e503",
+   "metadata": {},
+   "source": [
+    "## Instrument configuration\n",
+    "\n",
+    "Both `NirdaData` and `VisdaData` are dataclasses. All timing and per-pixel\n",
+    "geometry are recomputed automatically when a field is changed via\n",
+    "`dataclasses.replace()` or by constructing a new instance. The values below\n",
+    "match the current operational configuration."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 2,
+   "id": "d4e5f604",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "NIRDA\n",
+      "  ROI:               80 x 250 px\n",
+      "  pixels/frame:      23184\n",
+      "  first int time:    35.935 s\n",
+      "  other int time:    24.575 s\n",
+      "  data/integration:  278.2 kB\n",
+      "\n",
+      "VISDA\n",
+      "  frames/coadd:      50\n",
+      "  ROI dimension:     50 px  (9 ROIs)\n",
+      "  pixels/frame:      22500\n",
+      "  frame time:        0.200001 s\n",
+      "  data/frame:        90.0 kB\n"
+     ]
+    }
+   ],
+   "source": [
+    "# Mission-default NIRDA configuration.\n",
+    "nirda = NirdaData(\n",
+    "    reset_frames_1=50,\n",
+    "    reset_frames_2=1,\n",
+    "    drop_frames_1=1,\n",
+    "    drop_frames_2=16,\n",
+    "    drop_frames_3=0,\n",
+    "    read_frames=4,\n",
+    "    groups=6,\n",
+    "    average_groups=True,\n",
+    "    roi_x_size=80,\n",
+    "    roi_y_size=250,\n",
+    ")\n",
+    "\n",
+    "# Mission-default VISDA configuration.\n",
+    "visda = VisdaData(\n",
+    "    frames_per_coadd=50,\n",
+    "    roi_dimension=50,\n",
+    "    num_rois=9,\n",
+    "    exposure_time_s=0.2 * u.s,\n",
+    ")\n",
+    "\n",
+    "print('NIRDA')\n",
+    "print(f'  ROI:               {nirda.roi_x_size} x {nirda.roi_y_size} px')\n",
+    "print(f'  pixels/frame:      {nirda.pixels_per_frame}')\n",
+    "print(f'  first int time:    {nirda.first_integration_time.to(u.s).value:.3f} s')\n",
+    "print(f'  other int time:    {nirda.other_integration_time.to(u.s).value:.3f} s')\n",
+    "print(f'  data/integration:  {nirda.integration_data.to(u.byte).value / 1e3:.1f} kB')\n",
+    "print()\n",
+    "print('VISDA')\n",
+    "print(f'  frames/coadd:      {visda.frames_per_coadd}')\n",
+    "print(f'  ROI dimension:     {visda.roi_dimension} px  ({visda.num_rois} ROIs)')\n",
+    "print(f'  pixels/frame:      {visda.pixels_per_frame}')\n",
+    "print(f'  frame time:        {visda.single_frame_time.to(u.s).value:.6f} s')\n",
+    "print(f'  data/frame:        {visda.frame_bytes.to(u.byte).value / 1e3:.1f} kB')"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 3,
+   "id": "e5f6a705",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Overhead timing (mission defaults)\n",
+      "  NIRDA pre:   258 s\n",
+      "  NIRDA post:  102 s\n",
+      "  VISDA pre:   260 s\n",
+      "  VISDA post:  102 s\n"
+     ]
+    }
+   ],
+   "source": [
+    "# OverheadTiming models the pre- and post-observation MOC command overhead.\n",
+    "# Defaults come from the commanding timeline. Override individual fields with\n",
+    "# a Quantity to test different timing assumptions (e.g. nirda_pre_overhead_time=200*u.s).\n",
+    "overhead = OverheadTiming()\n",
+    "\n",
+    "print('Overhead timing (mission defaults)')\n",
+    "print(f'  NIRDA pre:   {overhead.nirda_pre_overhead_time.to(u.s).value:.0f} s')\n",
+    "print(f'  NIRDA post:  {overhead.nirda_post_overhead_time.to(u.s).value:.0f} s')\n",
+    "print(f'  VISDA pre:   {overhead.visda_pre_overhead_time.to(u.s).value:.0f} s')\n",
+    "print(f'  VISDA post:  {overhead.visda_post_overhead_time.to(u.s).value:.0f} s')"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "f6a7b806",
+   "metadata": {},
+   "source": [
+    "## Observation window\n",
+    "\n",
+    "Enter the start and end of the observation window in UTC. The duration is\n",
+    "computed automatically and passed to both instruments below."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 4,
+   "id": "a7b8c907",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Window:   2026-06-22 00:00:00.000  ->  2026-06-22 04:30:00.000\n",
+      "Duration: 270.0 min  (16200 s)\n"
+     ]
+    }
+   ],
+   "source": [
+    "# ---------------------------------------------------------------------------\n",
+    "# UPDATE ME: observation window in UTC\n",
+    "# ---------------------------------------------------------------------------\n",
+    "obs_start = Time('2026-06-22T00:00:00Z')\n",
+    "obs_end   = Time('2026-06-22T04:30:00Z')\n",
+    "# ---------------------------------------------------------------------------\n",
+    "\n",
+    "duration = (obs_end - obs_start).to(u.s)\n",
+    "print(f'Window:   {obs_start.iso}  ->  {obs_end.iso}')\n",
+    "print(f'Duration: {duration.to(u.min).value:.1f} min  ({duration.value:.0f} s)')"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "b8c9d008",
+   "metadata": {},
+   "source": [
+    "## Integration counts and data volume\n",
+    "\n",
+    "`solve_integrations` subtracts the pre- and post-observation overhead from the\n",
+    "total window, then packs as many integrations (NIRDA) or coadd-aligned frames\n",
+    "(VISDA) as fit in the remaining time. It returns the count, raw data volume,\n",
+    "and compressed data volume.\n",
+    "\n",
+    "The compressed volume is what gets downlinked."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 5,
+   "id": "c9d0e109",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "NIRDA\n",
+      "  integrations:      643\n",
+      "  raw data:          178.9 MB\n",
+      "  compressed data:   143.1 MB  (ratio 0.8)\n",
+      "\n",
+      "VISDA\n",
+      "  total frames:      79150\n",
+      "  coadds saved:      1583\n",
+      "  raw data:          142.5 MB\n",
+      "  compressed data:   35.6 MB  (ratio 0.25)\n",
+      "\n",
+      "Combined (compressed)\n",
+      "  total:             178.7 MB\n",
+      "  passes required:   0.64  (281.3 MB / pass)\n"
+     ]
+    }
+   ],
+   "source": [
+    "# solve_integrations returns (count, raw_bytes, compressed_bytes).\n",
+    "#   NIRDA count = science integrations (dropped-integration buffer already subtracted)\n",
+    "#   VISDA count = total individual frames, floored to whole coadds\n",
+    "nirda_ints, nirda_data_raw, nirda_data_c = nirda.solve_integrations(\n",
+    "    duration, overhead=overhead\n",
+    ")\n",
+    "visda_frames, visda_data_raw, visda_data_c = visda.solve_integrations(\n",
+    "    duration, overhead=overhead\n",
+    ")\n",
+    "\n",
+    "pass_data_volume_mb = 281.3  # MB per ground-station pass\n",
+    "\n",
+    "nirda_mb_raw = nirda_data_raw.to(u.byte).value / 1e6\n",
+    "nirda_mb_c   = nirda_data_c.to(u.byte).value / 1e6\n",
+    "visda_mb_raw = visda_data_raw.to(u.byte).value / 1e6\n",
+    "visda_mb_c   = visda_data_c.to(u.byte).value / 1e6\n",
+    "total_mb_c   = nirda_mb_c + visda_mb_c\n",
+    "\n",
+    "print('NIRDA')\n",
+    "print(f'  integrations:      {nirda_ints}')\n",
+    "print(f'  raw data:          {nirda_mb_raw:.1f} MB')\n",
+    "print(f'  compressed data:   {nirda_mb_c:.1f} MB  (ratio {nirda.compression_ratio})')\n",
+    "print()\n",
+    "print('VISDA')\n",
+    "print(f'  total frames:      {visda_frames}')\n",
+    "print(f'  coadds saved:      {visda_frames // visda.frames_per_coadd}')\n",
+    "print(f'  raw data:          {visda_mb_raw:.1f} MB')\n",
+    "print(f'  compressed data:   {visda_mb_c:.1f} MB  (ratio {visda.compression_ratio})')\n",
+    "print()\n",
+    "print('Combined (compressed)')\n",
+    "print(f'  total:             {total_mb_c:.1f} MB')\n",
+    "print(f'  passes required:   {total_mb_c / pass_data_volume_mb:.2f}  ({pass_data_volume_mb} MB / pass)')"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "d0e1f20a",
+   "metadata": {},
+   "source": [
+    "## Data volume vs VISDA coadding and NIRDA ROI height\n",
+    "\n",
+    "The two instruments contribute to the data budget independently — NIRDA data\n",
+    "depends on ROI size and grouping; VISDA data depends on how many frames are\n",
+    "coadded before downlink. The contour below shows total compressed data in\n",
+    "ground-station passes as both parameters are swept over their usable ranges,\n",
+    "using the observation window defined above.\n",
+    "\n",
+    "Because the two contributions are separable, we precompute each instrument's\n",
+    "data volume independently and broadcast across the grid rather than looping\n",
+    "over every combination."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 11,
+   "id": "e1f2a30b",
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "image/png": "iVBORw0KGgoAAAANSUhEUgAAA2YAAAJOCAYAAADcXRQRAAAAOnRFWHRTb2Z0d2FyZQBNYXRwbG90bGliIHZlcnNpb24zLjEwLjksIGh0dHBzOi8vbWF0cGxvdGxpYi5vcmcvJkbTWQAAAAlwSFlzAAAPYQAAD2EBqD+naQAAmh9JREFUeJzt3QeYE+X2x/Gzuyy9d5AiTTqIiBQLigoiKvaGgorYRfGKiI2mYFeuBctVwKuIgmIFAVGwAIoIUkQUBEGkqMDS227+z+/1P7nJbrZvSLL5fp4nsEkmk8lkNjsn57znTfD5fD4DAAAAAERMYuSeGgAAAAAgBGYAAAAAEGEEZgAAAAAQYQRmAAAAABBhBGYAAAAAEGEEZgAAAAAQYQRmAAAAABBhBGYAAAAAEGEEZgAAAAAQYQRmiAqzZ8+2hIQE9z+im96noUOH5umxvM9I76qrrrIjjzyyUG5HtLy2zKSlpVmLFi3soYceivSmIIrdfffd1r59+0hvBhAXCMzi/AQ7J5ecBEsjR460995777BsN+LT1KlT8xwQRjudGJ9zzjlWrVq1bAPfDRs22MUXX2zly5e3smXLWs+ePe3XX3/NsFxKSorddddd1qhRIytRooTVrVvX+vbta+vWrcvzOlG4vPnmm7Z+/Xq75ZZb/LctWLDAXW/evLmVKlXK6tSp446Nn3/+OeQ63n77bevQoYM7dipVqmSdO3e2jz/+OF/HeHrLly+3iy66yOrXr28lS5a0ypUr20knnWQffvhhjh6v59JzJiYmuteb3o4dO9zviJYJ3Bdr167N8PdQvx9HH320Pfvss5aamprj17Bt2zYrUqSI21+x5vbbb7cffvjBPvjgg0hvClDoFYn0BiBy/vvf/wZdf+2112zmzJkZbm/atGmOArMLL7zQzj333ALfTsALzJ577rlCGZzdd999Vr16dWvTpo1Nnz490+V27dplp5xyigu67rnnHktOTrannnrKnQwvXrzYnRh7mZDTTz/dfvzxR7vpppvsqKOOslWrVtnzzz/v1r9ixQorU6ZMrtYZLi+//LLb3kiLlu04nB577DG79NJLrVy5cv7bHnnkEfv6669dINSqVSvbtGmTC0KOOeYYmz9/vsuweZ555hnr37+/9ejRwx5++GHbt2+fjRs3zs466yx755137Pzzz8/1MR7Kb7/9Zjt37rQ+ffpYzZo1bc+ePW79CvRefPFFu+6663K0nmLFirlgVF9YBHr33XezfNxll11mZ555pvtZvyf6LLr11lvddmkf5oReswK7rl27WqzR+6Yvax5//HG3zwGEkQ/4fzfffLMvr4dEqVKlfH369Mnzvvz888/dc+v/eLFr1y5fLNL7NGTIkMP+Pufn+Ix2a9ascf//+eefWe7fRx55xN3/7bff+m9bsWKFLykpyTd48GD/bV9//bVb7tlnnw16/Kuvvupuf/fdd3O9TuSePhPr1q0blbvu+++/d+/7p59+GnS7jp39+/cH3fbzzz/7ihUr5uvVq1fQ7Y0aNfK1a9fOl5aW5r8tJSXFV7p0ad8555yTp2M8pw4dOuRr3bq1r3Hjxtkuq+fSc55//vm+o48+OsP9p59+uu+CCy5wy+hzJnCbddtjjz0WtLxer153zZo1c7y9V155pa9z586+WDV58mRfQkKCb/Xq1ZHeFKBQo5QRWdq9e7f961//stq1a7tvGxs3buy+Nfvn/Pwf+hZQy40fP95f7qGxFaJvFPWNvR6nUhF9+65vYlUiklcqu1JJlr451TbVq1fPbrzxRjtw4IB/GZVh6XkqVqzoSl9UapO+vMYb76TSkmHDhtkRRxzhsgjK/Olb0f3797sSjqpVq1rp0qXt6quvdrcF8kpf3njjDfcaixcvbm3btrUvvvgiZCmNMhiXX365VahQwU444QT//a+//rp7nPaRtlnfYqcvufnll1/sggsucN9e6nlq1arlltO2epTx1HpVVqRt1jYpCxJIr2HIkCHWsGFDt//03uob5PSvTdcHDBhgVapUcftF35T+/vvvOX6ftKwyqCqH0j7UutI/h3z55ZfuvVLJlLc9Wnbv3r3+ZXQ8KVvm7XPv4tEx2alTJ3d8aR9qX06ePNliRU7HIek1tWvXzl08TZo0sVNPPTWoREqlWaKysUA1atRw/2sf5XadmfF+ByZNmmTNmjVz6+7YsaMtXbrU3a+Mho41HbMnn3xyht/99OOwvPIxvacvvfSSNWjQwB0X2j6V2WVl+/btlpSUZP/+97/9t/3111+uhE3HRuDnlj4z9LtUUNuhUm5lk/Q69f+UKVPy/JmqTJMyVIHOPvtstz2B5WTffPONu23atGmWW9reokWLupLAQPo90u2BVA6r0kZlWgPpONPvduDvokr99NkTeIxJQY+10/usfaj3PKf02ass8E8//eS/TRnBzz77zN2XU3q9+t1SaWJOKBP7ySefuMxiVvT7oWNn4cKF7n3QPtTftxdeeCFoOf2te+CBB9znnLKd+ow98cQT7fPPP8+wzokTJ7rl9Bmu96Zly5Y2evRo//0HDx50f//0HuvY1e+J/obob0mg0047zf3//vvv5+g1A8gbShmRKZ0o6GRcH/YKhFRXr3KMgQMHuuBI5U6i0sdrr73WjjvuOH9JiU5iRCcwc+fOdQGEAgmd7IwZM8b9AVKQoqApN/744w/3PPpjrOfSCaS2RSeXKm/RCcXmzZvdHzVdV5mN/tAoaNRr0XLnnXde0DpHjRrl/gBqgLPKvVSeo3IuncxpXICCKpXwqERHfyT1BzHQnDlz7K233nLPpRMtlYudccYZ9u233waV/YgCEP0BVOmndyKmsRf333+/G8eh/fjnn3+6bdAJ06JFi1yQpT/E3bp1c4GNSmh0QqnX/dFHH7l9oT/OGoehEiKVHw0fPtxti16PypICTxC0H7766iu3/1SmqhNovZcaQxI4TlDbooBRJyzanzp5ye7EwqOgSif2Gs+k/aIgWseJ1pGeTuj1XulEWe+V9ptevwI73SfXX3+9e+9DldqKTjT0unr16uX2lU5GtK+1f3K6zdFO792SJUvsmmuuyXCffidmzJjhyr10Anbssce6kzUdVwr0dfKvY0EBuAIL7yQrN+vMioJrBQw333yz/3dKx6KeT78P+nJGv0uPPvqoe65Qx0F6EyZMcM+t914nwnqsAhZ96aLfz1D0u6LfOX0xouNOdKzr8Vu3bnWfOQowvG3WyWxBbIf2k740UWCq1/7333+7L3L0mZeXz1Rtl06AFfjoZFqP0++xPpO03V45mX7Wbccff7zllj6Xta8y25fpt1ufq96+8+hzXJ+p+n1V4KhSRv2sL4tuu+02K2gKavXZovXreFNAeskll+T48fpM1Xui91SfkaLPbgWSWX1O6PNJAb7oPdHzKtAaPHhwjp5Xfwf1ue6VQ2ZFvydaTn8PVEKpL0f02ai/bd7vqbbhP//5j7u/X79+7vh85ZVX3N8IfX7quBJ9XmoZfRarRFUUXOtY8t4f/X3TMev9Dde6v/vuO/v+++9dObRHf2P0d12P1RdnAMIk0ik7RI/0pWLvvfeeu/7ggw8GLXfhhRe6koZVq1ZlW8q4Z8+eDLfNmzfPrfe1117LdYlb7969fYmJib4FCxZkuM8rp7n99tvdur788kv/fTt37vTVq1fPd+SRR/pSU1ODnrNFixa+AwcO+Je97LLL3Ovr3r170Po7duyYoSxJj9flu+++89/222+/+YoXL+4777zzMpTSaN2B1q5d60rGHnrooaDbly5d6itSpIj/9kWLFrnHT5o0KdN989RTT7llVCqUmf/+979u/wXuG3nhhRfcY1XGJIsXL3bXb7rppqDlLr/88hyVIT399NNuubffftt/2+7du30NGzbM8D6HOkZGjRrl3gPty5yUMqZfh95Pva9dunTxxZKsyry8+4YPH57hvueee87d99NPP/lv++ijj3w1atTwH6O6dOvWzf0u5HWdoWgZlbl5pWry4osvuturV6/u27Fjh/92lUbq9sBl05f7eeVjlSpV8m3dutV/+/vvv+9u//DDD7PcHh0n1apV81+/4447fCeddJKvatWqvjFjxrjb/v77b3d8jR49ukC2Q+Vx2tfbt2/33zZjxgy3XOA6c/qZqs83LTd16lR3fcmSJe76RRdd5Gvfvr3/cSoXbNOmjS8vatWq5cr3ckKfG3r+V155Jej2zZs3+0499dSgY6xy5cq+uXPnZrqu/JQyXn/99f7n0eeY9lvge5MZ7/NXz33nnXe6zyGPShKvvvpq93NmpYyhLjfeeGNQCWdW7r///hyVtKrUUet+4okn/LeprFTHl45f7++UyjjTl5tu27bNHffXXHON/7bbbrvNV7ZsWbd8ZlQO2qNHjxy9jq5du/qaNm2ao2UB5A2ljMiUBjirXMT75tmjMhz9DctJ+UxgOYtKJvRNssqa9M22vpHLDX27r4yOvplVRiA9r5xG261v/gJLBfWNqDJEytjpW/NAvXv3DvrWWG2B9frSZxF0u8oLDx06FHS7yrZUKuJRSZ4GSuub8PRdu2644YYMg871uvTtqL6R9S7KiCmz5pWmeIPztU59exuK9qnom/bMmhgoA6UsmTKNgc/XpUsXd7/3fNqHkv69V2lnTujxKptTWahH2dFQg/QDjxF9I67tUYZO74EyhjkRuA5946xv1JV1yO0xFs280k5lQtNTCVLgMqISVDVaUEZWvzf6ZlwZFmVy8rrOzOgb+cBSNa+1trJIgdk27/acdHxUJkQlvx4vu5XdY7WcsjsrV6501/WalSnR7frZy6Lp+MpJxiy77di4caMrj1NjisAmGso2KIOWl89UvW/6zPJKorXdyvTos0rHtD4DtLxeR05eQyj6LA58XZlR2Z8yofqc02sMpN9pZWN1uz5bXn31Vfd7r4yiMrQFTZ8/ygKpAqJ79+7u8zWwhD0nVAGgbVMWy/s/uzJGfW7peXVR0xHtD5Xo3nHHHTl6Tr3vOc3cqzxS2VmPMmW6vmXLFlfiKDqGvHJTfdYrG6y/S/q7GPiZp78J+kxNX5YYSMuo2kKl8tnR8eJlDgGEB6WMyJTGh6kELX0Zk9elUfdnRyd1KpMYO3asK9UJHEcRODYqJ1QKojKL9OWBobY71JwrgdsduA4FUoG8kyuNX0h/u/4IarsDO9UpgEpPXfB08qRtDhzHolLIQPpjqH0Sah3iBYx6nE4CnnzySTeeTSdjKme64oor/NurE0iVt6gkRWWZOlnWCZKCI5U7ec+nUhadtIeiP/7ePtJjvJJUj07CckKPVwAeOPYks8er3FHloSpNUlAVKKfHiEoWH3zwQXeCHDiOLf3z54RO9HSikxc6WVLpYDh4wWeocXoqIQtcRkGDOi2q06qCI9GXBQqeNJZKAYBObHOzzqzk5ndI0r/POVmnF0Rk91gvUPGCGQX3OjZ0zGssl3efSgRbt26d7+3wPgdD/Q7reA88Uc7pZ6pOvBUIeYGkV3apL5sUjKi0WmOcdJzmNTCTwM/jUDT+SgGF3jeVLGq7AqlcWIFEYNt6HWfaF/fee68rEyxI+kJJF1GQqg6H+qLOG2uXEwp6tQ6VMyoo0eez98VUZvR6vPJf0eeqnu/pp592X+Bp3FZW+1DHgFc6mR0dHypDTv/3RPTFosZLi4LTJ554wgXO+tIz1N8YlRCrFFK/6xpDrf2lLwFVau/Rduk903Po76Luu/LKK11JfKjjJS+fqQByjsAMYaXxUArK9E2nTjT0B14f7BpzFi2tqdOfbGR3e3YnM1lJf5KrfeAN3g/1fPrW3KM/wjqpVkZMY1r0rbuCXp2k6QRU69Y37Mp6qdGJxkDoxEgnHVpe69fz6SRCAV4o6U+kw00nmcos6ARz0KBB7oRJJyUK4vVac3KMeGNulBXReCZ9Y6+AVsedTr7yMvZGQU1eqMV8uCZJV8CnzJYyNOl5t+mkTjQeUoGVxnkF8sYmaZyITtZys87D/TuU18dqe3Vyqt8FBaJaXp89Csw0rkbBj44ZZWW9LyzCsR35pSBM2U69j9peBTreGDpd9xq75DUw05dLWQW5+lJEx4jGsOr50h8HCv71GaPGKIF0TGnbA8e2hou+dFI2SeNjc/qlkShDprHOCpD1hVZOjoP09MWXphHQcZZVYKbPdmWf8/qZEorG/urzUc2VND5RDVh0nOrvwerVq/3L6XZ9WaVKC22HLvpcVFCrwE70uanHeH9X9OWexjqq4Yi+5Auk40VzyAEIHwIzZEoT0n766acZBv97Ha10vyezb9H0LavKXBRUeHSikZtOWh6dWOlb7mXLlmW5nLbLK2MKFGq7C0KoEhCdKKjMJ7PMlEcZKZ3g6UTS+1Y0KzoB0EVzAimA0KB//QFVRkB0gqETBl0UfKnJiE7oFKzpG189nyYK1f1ZffOpfaSgSH+wA094Qu3XzB6v9yn9N6zpH6/GI9pXOknQyYInVOlNZtur0iKd+OjkI7AkTycgeaEsSlalP1nJSWlYXum91XuvgfnpKWOgyXe931OV8mnfpy+l9b5Z98pxc7POWKJgRSfM+r1SIwS9Br2v+mJIwYQyGOpEVxC8z5NQnwPpj/fcfKbqNSh7q3m39EWFF4DpRNoLzPSZkb7zZk7pS5A1a9aEvE+f0cpE6XdT25u+JNM7xiTUJMs6ztKXfIeDV2ab2+oLBWbK0uvLh1DNhHLCe32aBzAr+pJMQVlOMs+iJkcqPwzMmnmTe3vlwvq7qt9NlcIHfi6q226oLL7eS130ma4smsow1RhIVQ1eMK0SZ130enSMqfQ5fWCm4yUnWWYAeccYM2RKnaH0R1ffCgbSt2n6Y6BvUz36IxIq2NK3eOm/WVbXrlB/zLM9WBMT3TeEKpsJdSLpPY+2W52p5s2b579Pf+j0za7+sIU6ycgPPU9guZLGoenbR5WNZPZte2BJjJbRSWL6/aTrGgciKuFMf6KjE2rtE68MLVT5ndedy1tGZSw6ydNkuqFOcrSfxHtvA9uOi0p3ckLvgU4wAlvWq7Qz/bfr3v4JfO36ObCds8c7UUl/nGkdOh4DjymV/AR2mMxtcKUgNi+XwLGG4coQaExM4PGvk391OVRZmUcn7NqP6dvd6yTfK+fK7TpjiYIYHQPKGHsBjX5XlCXTFxYKHPJTAhhIGVr9nunLhfRTV6Qfz5qbz1SVYyvzq256OnH2OiJqu5UlVzfY/LwGZRH15Un6MlZtn7JI+lzTuDEtF4pO6rVPtY8Df3/VTVWBY+Axlhsaw6RANXAsrVdiHUjvoUp1FfDk9jNdX1Dps0wZJo1HzguvfDOrQEXbqOMgN51h9TmvwMmj4FzX9SWf9/kS6nNTX6QE/s0T7++HR++XV6Love/pl1GVht7b9MeFjm19UaffIQDhQ8YMmdI3bPqmTxkXneToD5BKHRR0qDQxcPyR/mDom1Wd9HilRDqxUCmVvpHUN9X646k/HFoucIxWbigDpG1QyZjX7l3feuoEQgPhVeqj8VU6AdVJjsr9dFKjkyZ926fsSl7KVrKi0iK1KQ5sly85+UZe+1DZLrVd1j5W4Klv0rWtmgdJr/HOO+90J8maK0onyjrp1h9v7Vf9gfbGEGmsgLIEOgnQN+86mdG2qMzRa4SisQM6WVcTEmXRlHHTiZhOhHS7sk4aQK4TTbVZ1uP1B1l/jGfNmpXjAf1q4ayTT2XBNGBdJ6/a3vTTI+hbe+0DvUYFjMqI6j0KVWLlnZRoP2t/67WrJFavV8edxkbom3C9bs15ppMLtYKPBdo3KrHzTkb1PnpZUL1nXiZF33YrqNZr1j7Tibteu7ImaiDhUZmTxlOpzEtjrHRSry8PVKaknwOnjMjpOmOJF7AowNRnhkeZAJVzefORFRSd4Gv/6fdMY470JYm+gNK+Dsyo5OYzVb8rOuYVhHlzmHmvQV+g6JKfwEzjikaMGOECPH2J5NF7rvGeek69DpXNBdK4VlGgoNeqY8obz6pMoD4z9CVP+lbyOT3G9bmhz059Pqkdv+g41pdTeu0aK6VxWxprq88tVWMElnznVG7a+et3x9sPeo36LNTnlD4XA/ddevqbpO3OTWCmv58KxnV86LNega/KEfWlljfmWH9XlS3T77HWrb8XqpzQ39jA400ZL72HKmfX3wHtfx2X+nz3xjXqMdrPOtb0t1Jf0OgLNf29CaS/2woEddwACKM8dnNEIRSqHblaaw8YMMBXs2ZNX3Jysq9Ro0a+xx57LEObYLXUVkvqEiVKuHV4rfPVwletiNVCuXTp0q5dt5ZV6+DA9vo5bZcvaqGutvlVqlRxbbrr16/vtj2wffDq1atdK+Xy5cu71vXHHXecax8eyHvO9C3ox44d625P35I/sOWyx2uv/Prrr7t9o+1R++r0ryPUYwO98847vhNOOMFNO6BLkyZN3HpXrlzp7v/1119dG+QGDRq411OxYkXfKaec4vv000/965g1a5avZ8+e7r0qWrSo+1/t+X/++eeg51LL5UceecTXvHlzt70VKlTwtW3b1jds2DBfSkqKf7m9e/f6+vfv79qFa5vOPvts3/r163Pc6lrvk9p5lyxZ0r3/at38ySefZHiff/zxR99pp53mjg8t169fP98PP/zgltN74VHL51tvvdW972otHnisqo23t/+17/Q4b5/HAq9NdqhL+mNJ74GObbXB1j4766yzfL/88kuGdf7+++/umNE0EToe1M5d+zbUMZjTdYaSvsV4YJtxfVZk9zuXWZv69I/1niunbdbVXlzLq6W756uvvnK3nXjiiRmWz+926HdYrcR1DDZr1sz37rvvZlhnbj5TZeDAge659PsayJt2Qp9z+dGqVStf3759c3wspv99OnjwoO+ZZ55x7dx13Oiiz6XPPvssz8e493sbeNubb77pPiPUDl7TiOgzS9c1dUFOZPf568lJu3w9v/7m6L0JnHoiFLXm17GQU9pH+lzW9CuankWf9Tp+nn322aDldKyMHDnS3ef9zdHft/TH2+TJk12Le/0u6DOgTp06bsqBjRs3+pfR1A36+6i/lfr7rc9PTdMSOIWMXHLJJe5vFIDwStA/4Qz8gMJM32KrdXL60iQAiHbKYunzS51Rvek2UHCUjVJ2S5OS54QyVyrlzG4c9eGmDKWqYCZOnEjGDAgzxpgBABCHevXq5aYDUOkvCpbGhmmsXuC8gbFK4/E0ppkyRiD8GGMGAEAc0njbaMvOFBbqhhiqS2IsevjhhyO9CUDcIGMGAAAAABGWGE3fyGi8jjpTBc6lovp3dfBT1yV1n/PmTvGoNl5didTBSpMparLFwzF/CiAaosn4MgBAfmlyejKYQHyLisBMc+hong5vfg3PgAED3FwhaoWulr6aF0kteT1q862gTLXcmmxXLdHHjRvnJo4EAAAAgFgR8a6MmnPjmGOOcXOfaE4Tza+hgaaaO0nzpEyYMMFNgCqas0Rzb2gurA4dOrj5aNTxSAGb5twRzeUxaNAg+/PPP12NNwAAAABEu4g3/1CporJep512mn+ySdGktAcPHnS3B05Gqw5SXmCm/9UpyAvKRBPP3njjjbZ8+XJr06ZNyOfUjPaBs9qnpaW5SRhVMulN4gkAAACI8hiaYFyTgKtxTrTSMCBVkoWTEh/FixcP63PEq4gGZpoT4/vvv3eljKHmzdAbn35uFQVhus9bJjAo8+737svMqFGjbNiwYQX0KgAAABAP1q9fb7Vq1bJoDcqOrFvKNm9JC+vzVK9e3dasWUNwVpgCMx3Yt912m82cOfOwv7GDBw+2O+64w39dZZPKxC37rrqVKf3PtyCrDyUFPWbtgcr+n2uVPtmW70qxvw/8HrTM+r0VQz7fhr3lQt7+557SIW/vVPkoW7t1v/2UEtzoJNDB3Tkr00zaHfw6sl1+R+6+Berb4Rh7c/YPdjA11fKj6K58PTzj+nYevgrdojvy99oLyhUXtLe3xn5lsS55+75Ib0LUS9i+M9KbgDBJ27qNfQtEoUO+g/bFvnetTJkyFq2UKVNQtmxBdStTJjxZvZ0706xFu03uuciaFaLATKWKW7ZscePLApt5fPHFF67L3fTp092bvn379qCsmboyKlIX/f/tt98Grdfr2ugtE0qxYsXcJT0FZWX//0AufSj4gC554H8BTqnSxaxEQlErvj85aJmiSaGDpSKJGZ9Lkiz07cVLl7Tk/YmWeDDzgDUxLWeBWWJqLgOzA7n7RS5eqpQlFStmaan5+3YmqYCz7klFD19gViQ5OgKzEiVLWZEisV9aUCQposNeY0JCYnjLVBA5aQmMjQaiWSwMeVFQ5p3PIrZE7F079dRTbenSpbZ48WL/5dhjj7VevXr5f05OTrZZs2b5H7Ny5UrXHr9jx47uuv7XOhTgeZSBK1u2rDVr1sximc9i5eQ0wSLbPgYAAACIfRHLmCkV3KJFi6DbSpUq5RpweLf37dvXlRxWrFjRBVu33nqrC8bU+EO6du3qArArr7zSHn30UTeu7L777nMNRUJlxApShJtZRo0Y+OIIAAAAiHoR78qYlaeeesp1vtHE0uqiqI6LaqvvSUpKso8++sh1YVTApsCuT58+Nnz4cItlsRbrxE52DwAAAIhORaJt1vtAGlT43HPPuUtm6tata1OnTrXCFjrFSqiTEHNhZOHNXKaRxQUAAIhZjAxEvhEPRF5iQoL50mIlnAcAAEB6BGZRKlbGsClTQylj5CUkJpAxAwAAiGEEZlEoFlqxeihljKKMWWzE8gAAAAiBwAz5RkAQHcF8rGRZAQAAkBGBGfIlhpJ7hT4wo/lHfEjYtjPSmwAAAMKAwCxKkftAbiQkGs0/AAAAYhiBGVBIxNLYRAAAAAQjMItSnGIjN9JSfQRmAAAAMYzADPlCv4nooMYfifw2xwVfhTKR3gQAABAGnMoh36igi44AmVJGAACA2EVgFqXZj1g5yVYnQOYyi7y0tDQ3lxkAAABiE4EZ8o14IEoC5EQCMwAAgFhFYBalYuUU20dj/6gpZSRjBgAAELsIzKJwlrFYm8OMUkYAAAAgfwjMUABNJ9iJAAAAQH4QmOVRuJtzxE4WSvm9WNlWAAAAHE4bNmywK664wipVqmQlSpSwli1b2nfffZflY5577jlr2rSpW75x48b22muvZVjm6aefdvdpmdq1a9uAAQNs3759/vvHjBljrVq1srJly7pLx44dbdq0aRbNikR6AxDb47aYxwwAAAChbNu2zY4//ng75ZRTXFBUpUoV++WXX6xChQqZ7rAxY8bY4MGD7eWXX7Z27drZt99+a/369XOPOfvss90yEyZMsLvvvtteffVV69Spk/3888921VVXucTJk08+6ZapVauWPfzww9aoUSPX8Xz8+PHWs2dPW7RokTVv3jwq3zACsygUO2HZPyhlBAAAQHqPPPKIy2aNHTvWf1u9evWy3FH//e9/7frrr7dLLrnEXa9fv74tWLDArcsLzObOnesCvssvv9xdP/LII+2yyy6zb775xr8eb1nPQw895IK++fPnR21gRiljnoW5fC9GqgMpZASAgpNYqSK7E0Ch8cEHH9ixxx5rF110kVWtWtXatGnjMmFZ2b9/vxUvXjzoNpUrKnN28OBBd11ZsoULF7rb5Ndff7WpU6famWeeGXKdqampNnHiRNu9e7craYxWBGbRmteKkbRZQuxsKgBEvbS/t0Z6EwAgWzt27Ai6KJgKRQGTslQqJ5w+fbrdeOON1r9/f1dWmJlu3brZf/7zHxd4qQRR49F0XUHZX3/95ZZRpmz48OF2wgknWHJysjVo0MBOPvlku+eee4LWtXTpUitdurQVK1bMbrjhBpsyZYo1a9Ysat9hShmjUIwky/wYZwYAABAdVh9KstKHwpN72XXon7NUlScGGjJkiA0dOjTD8mlpaS5jNnLkSHddGbNly5bZCy+8YH369An5HPfff79t2rTJOnTo4AKzatWquWUfffRRS0z853XNnj3brfP555+39u3b26pVq+y2226zESNGuMd71Bxk8eLFlpKSYpMnT3brmTNnTtQGZwRmUSh2OjIyvgwAACDerF+/3nU69CgjFUqNGjUyBEHqtvjOO+9kuu4SJUq4ph4vvviibd682a3jpZdesjJlyrjmIaLg68orr7Rrr73WXVenR5UpXnfddXbvvff6A7iiRYtaw4YN3c9t27Z1Y9VGjx7t1h2NCMzySBF8OMVSZ0aKGQEAAOKH14I+O2rQsXLlyqDb1EGxbt262T42OTnZdVYUjQ8766yz/AHXnj17/D97kpKSsj1HVwYvs7LLaEBghnxRW1JKGQEAAJCe5hZTow6VHV588cWuWYeyX7p41Bpfc5299v9zlSlw03IqUVS7fbW/V/lj4Lg0dVzU7SqN9EoZlUXT7V6ApvV2797d6tSpYzt37nQt9lUCqbFu0YrALE/CW2q469A+25d6yGLB79t3xFh2r/DatTt6vwECAADxR/OQqeGGgiQ161CrfE0M3atXL/8yGzdutHXr1gV1UHziiSdcpk1ZM82Bpvb4aonvue+++1xyQP8rqFOJo4IytcT3bNmyxXr37u3WX65cOTfZtIKy008/3aJVgi/cNXkxQN1k9Ib99lNNK1vmn7ToL4f+ibY9vx74p6ZVapc+3Zbs3Gp/H/g9aJnf9lYKuf71e8qHvH3L7tKZblPKzhJZbvPBXUUtJ5J2Bb+O7BTZkfvBosm7LN+K7sz/OoLXd/gO62IpqRYtklP+aSMby5K37Y30JkS9hG0F/AuDqEFXRiA6HfIdsM/2vuWaSOSkhC+S57OfLattpf//fLag7dqZZl1arI/q/RDLaJcPAAAAABFGYAYAAAAAEUZgBgAAAAARRmAGAAAAABFGYAYAMYTGHwAAFE4EZgAAAAAQYQRmUah8cklLTjebeTQ7tt4RVrVsqUhvRlwrW6a4FS0aelrCxMTwzruHw8tXoQy7HACAQih2zv7jyPl1jrPEhH/emrLJxe2OFif7L3e2PMWizUmN69lZRze1To3qWAIxQESc3bWVFU3OOGddctEkO/+CdhHZJgAAAOQcgVkUUmyzP/WQ+3nHwX22L/WQTVi90F5f9Z0dTIueyYw9h9LS7NUvvrOkxES7olMbK1+yeKQ3Ke4kJSXZrt37/de7n9na/X/wQKoVK54cwS0DAABAToSufUJEJbjQzPvZXBZq096d7vrBtDSLRtrGL1eutV82/WXnH9vCFq/baN+v3RDpzYofPl9QtvKIWhVcCWNams9d132+f34EAABAFCIwi0LbDuy2TlXr2ZKtG6xjtXq2YXeK/z6fRc/Z9dXtj3H/lylezHqf8M/P2jxt41lHNyEwO4x27dlvRzWoZmu+/92aNK1pqak+a9Gytu3de8D27zt4ODcFAAAAeUBgFoVmbFxiXat0sC41G9lvu7baO2t/8N/3xcbVFi3mrllnPp/PqjVpZvNX6ef/3efzrY3kpsWd2V//bOf3aGM9Tmhmv6/fau+9+5117dbSkpOT7JNPlpAtAwAAiHIEZnkS3qzVzkP77NWfvwl53/LtmyxarNzyl/v/c9+vtnLjPz8jMrZu323/eeMrK7k3zY0rk7cmzuftAAAAiBE0/4hCZ9Y82mLBKY3qu/8ZSxZ5p3duZkmJCf6gDAAAALGFwCyPEsLYF/7nnRstFuzYty/Sm4D/t2rNFkv9/0YfAAAAiD0EZlFo1c7NFgsWrv8j0puA/7dmHaWkAAAAsYwxZlGobcV69u2+bbbr4H4rmphkNUuW89+nRN2anVstGjStVsXWbdtuB+ygJSYkWNkSxYIyitt2743o9sWT1s1r2a+//WX7Ug5akSKJVqPmP+3yNRxS/69Z82ekNxEAAABZIDDLs/CVMh5T8Uj7/Lf/Nfno1bCtbdu/17Whr1q8tA1bNN2iQZej6tuLXy9we6JokSS7+bSObrLpNJ/PSiQn24j3Z9EN8DBp3by2rfjln2MmNTXNzuzR2nbv2m8HD6ZajZrl7blnZrqfAQAAEJ0IzPJALeLDSYGN9wwH0lJt6/49NmbF1+76jU2Pt2ih7UxNS3MH0b6Dh2xzyi77z5wF7r7rTjku0psXf8fk/x+X+i8lZa9NeusbF6RdennHcH6PAAAAgALAGLMopLLA4kn/xMylk4u5AMiTEEVn2NrO5KQk97MyZiqz1G0Sxt4oCEG7u3jxZPdz8RLJLjpTSaN7nxJ11PCGAAAARDMyZlHox5QNdkXDY+3nlC3WokJN++6vdf77/pdLi7xVf26181o3s59/3WJH161pP2/6yx9EqkOggoFo2t7CbNnKP6zHaa1s3YpN1uio6vbTjxv8pYuHDqYSKAMAECfWHqhsJQ/888V5QdvjpuVZH5Z1g8AsKn39589WLznNapYqZ3M2rbLl2/433uyln+ZatJj+0y/WucGR1qJWNVuzZavNXfWb/75J3ywJyvQhvL5fss527dpndcqVte++/dVWrvzflAtvvxV6snIAAABEDzJmUWrx1g3ukl5qlAU7c1avteRdGW9P2bs/EpsT15S5XJOS8ZgBAABA9CMwi0KdKh9ls3b/4Rp/BKpeooyVLFLUft35t0WTc9s2s9+3ptjCtRvowhhBpUoWtWb1a1qFCqVcMxA1AFn50x+2Z8+BSG4WAAAAcoDmH1Ho+CpH2dVHtbdi/98AxLPn0EHrekRjizZ1KpW3qmVL26XtW1u5gLnMcPjUr1vFLjirrVWrVtbqHlnZSpQoapUqlbLLenWyunUr81YAAABEOQKzKPTX/p22MmWL9W7Yzt+dUXYc3GfJiUlR2V9v2pKVNmflGrvouFZuzBkOr07t6tv70xbb9E+W2mvjv7Tk5CSbM+cne3vifGvfocE/nRoBAAAQtSIamI0ZM8ZatWplZcuWdZeOHTvatGnT3H1r1661hISEkJdJkyb51xHq/okTJ1osU8v52RtX2Yrtm13mrGxycXe7ArLoGmH2P0USk+yPbTts3JcLrW6l8nZhuxZ0AjyMfP8/p5ykpfqsZKliVqxosu3cuc+SixaxpES+gwEAAIhmER1jVqtWLXv44YetUaNG7sRy/Pjx1rNnT1u0aJE1adLENm78X2c5eemll+yxxx6z7t27B90+duxYO+OMM/zXy5cvb7HM9/9B2Febf7WDaal2Q9NO9uO2zVatZBn7JeXPqAnO7u92sgvIEg76bPDZJ/tv13upAHnKwuVR16yksNq2fY+1aVnHVh1YZ/UbVLMdKXvt4MFD7r601DQmmAYAAIhyEQ3Mzj777KDrDz30kMuizZ8/35o3b27Vq1cPun/KlCl28cUXW+nSpYNuVyCWftlYtiJlgz/4+ubP3+y3XVutSflqtuGv7bbo7+jpuvfIp1/aobQ0G9Cxo/1n9gI7cEjzZf2v0FJzmeHw+PSLFdblhCbW87xjbevfu2zWp8tt//5Dllw0yebNW2X79h7krQAAAIhiUdOVMTU11ZUo7t6925U0prdw4UJbvHixPffccxnuu/nmm+3aa6+1+vXr2w033GBXX311UICQ3v79+93Fs2PHDosm8/76xcxK+K9v2rvTXaLNgdR/uka+NX+J7TnAiX9E34uDqfbJ58stOSX4fTh4INXWrvkzYtsFIHcSK1W0tL+3stsAIA5FPDBbunSpC8T27dvnMmHKijVr1izDcq+88oo1bdrUOnXqFHT78OHDrUuXLlayZEmbMWOG3XTTTbZr1y7r379/ps85atQoGzZsWJ63OaugLx5t3hFiIjMAAAAAsROYNW7c2GXCUlJSbPLkydanTx+bM2dOUHC2d+9emzBhgt1///0ZHh94W5s2bVzGTePQsgrMBg8ebHfccUdQxqx27dq53HLK9AAABYtsGQDEr4i3aitatKg1bNjQ2rZt6zJZrVu3ttGjRwcto4Btz5491rt372zX1759e/v999+DShXTK1asmL8TpHcBAAAAgLgNzNJLS0vLEFSpjPGcc86xKlWqZPt4Zd8qVKjggi8AAAAAiAURLWVUSaFa39epU8d27tzpyhVnz55t06dP9y+zatUq++KLL2zq1KkZHv/hhx/a5s2brUOHDla8eHGbOXOmjRw50u68887D/EoAAAAAIEYDsy1btrjyRM1XVq5cOTfZtIKy008/3b/Mq6++6uY769q1a4bHJycnuy6NAwYMcHNnqSTyySeftH79+h3mVwIAAAAAMRqYqUQxO8qA6RKKJpUOnFi6sCifXNIOFUm23YcOWLSrXKqkpezaE+nNgJnVrV3J/kjZxL4AAACIQVE3xixWKEMXLq0r1LW6pStYLLjw6BZWJJHDKBp0Ob5xpDcBAAAAecQZdZ4wj5l/T7ArAAAAgHwjMItCsRbr+JjTDQAAAMgXAjPkS0LMhZGFVxirawEAABBmBGZRinNs5LaklMwlAABA7CIwQ76RqYm8xIQE3gcAABB1NmzYYFdccYVVqlTJSpQoYS1btrTvvvsuR4/9+uuvrUiRInb00UcH3a75j2+//XarW7euW2enTp1swYIFQctcddVVlpCQEHSJ9m7uEW2Xj0LUAIQUX0Sx+wEAQLTZtm2bHX/88XbKKafYtGnTrEqVKvbLL79YhQrZdx/fvn27m+/41FNPtc2bNwfdd+2119qyZcvsv//9r9WsWdNef/11O+200+zHH3+0I444wr+cArGxY8f6rxcrVsyiGYFZlGLkFnIjLc3nsmYAAADR4pFHHrHatWsHBUf16tXL0WNvuOEGu/zyyy0pKcnee+89/+179+61d955x95//3076aST3G1Dhw61Dz/80MaMGWMPPvhgUCBWvXp1ixWUMkahWMp+aFwTDUCiA3EZAACIJh988IEde+yxdtFFF1nVqlWtTZs29vLLL2f7uLFjx9qvv/5qQ4YMyXDfoUOHLDU11YoXLx50u0oav/rqq6DbZs+e7Z63cePGduONN9rff/9t0YzALE98rk4VAAAAiDc7duwIuuzfvz/kcgqulMVq1KiRTZ8+3QVH/fv3t/Hjx2e67l9++cXuvvtuV56o8WXplSlTxjp27GgjRoywP/74wwVpWnbevHm2cePGoDLG1157zWbNmuUyd3PmzLHu3bu75aMVpYxRKlayUGr8QYwKAAAQHX49UMWK708Oy7r3HTjo/ld5YiBltlROmF5aWprLmI0cOdJdV8ZMY8NeeOEF69OnT4blU1NTXfnisGHD7Kijjsp0OzS27JprrnHjyVTqeMwxx9hll11mCxcu9C9z6aWX+n9Ww5FWrVpZgwYNXBZN49aiEYEZCqDwMjaCSAAAAOTf+vXrrWzZstk21ahRo4Y1a9Ys6LamTZu6MWKh7Ny503VsXLRokd1yyy3+4M7n87ns2YwZM6xLly4uwFIGbPfu3S5jp+e55JJLrH79+plus+6rXLmyrVq1isCs8AlfMBJL81GRMQMAAIgvCsoCA7PMqCPjypUrg277+eefXZv7zNa7dOnSoNuef/55++yzz2zy5MkZGoeUKlXKXdT9UaWSjz76aKbb8vvvv7sxZgriohUZs2hFEgoAAAAxbMCAAW6OMZUyXnzxxfbtt9/aSy+95C6ewYMHu7nOXnvtNUtMTLQWLVoErUPNO9ToI/B2BWHKoqmphzJgAwcOtCZNmtjVV1/t7t+1a5crh7zgggtcV8bVq1fbXXfdZQ0bNrRu3bpZtKL5Rx7oQAin2MmXUcgIAAUpsVJFdiiAQqNdu3Y2ZcoUe/PNN11gpYYdTz/9tPXq1cu/jBp2rFu3LlfrTUlJsZtvvtkFY5rr7IQTTnDBWnLyP2PrNO5syZIlds4557ixan379rW2bdval19+GdVzmZExi1Kx0/yDDpUAAAAI7ayzznKXzIwbNy7LXTd06NAMjUWUfdMlM2qdr0At1pAxQ9xk9wAAAIBoRWAWjcJcKlnQYiO3BwAAAEQvArMoLTWMlWCHUkYAAAAg/wjMorSlfazkzBISEsLeDAUAAAAo7AjMolFCrOTL/kFYBgAAAOQPgRnyJbZCSAAAACA6EZjFaalkQaGUEQAAAMg/ArM8BiP4/31BKSMAFJi0v7eyNwEgThGYRSEX9sVGwsyh9wcAAACQPwRmeeaL2Vb8BYnkIQAAAJB/BGYoADGU3gMAAACiEIFZlIqV5h/K71HKCAAAAOQPgVmexE6p4eEoZYydIBIAAACITgRmeeQLY5oolsK+WBoPBwAAAEQrArMoFUs5KEoZoyNzmZoWS0cNAAAAAhGYId8oZYy8RNpjAgAAxDQCM+Qb5YyRl0baEgAAIKYRmAGFgOIysmYAAACxi8AsSsVSSw2q6KID7wMAAEDsIjCLQrHUwoHxZQAAAED+EZgV+tAp/BhjBgAAAORPkXw+Pm4lUDcGAACAKLN+b0UrmlQ0LOs+sPdAWNaLf5AxQ77QDBAAAADIPwIz5BvJQwAAACB/CMyiVOyM22K8HQAAAJBfBGZRKPY6HcZKEAkAAABEJwIzAAAAAIgwArM8I0vkNf9gjBkAAACQPwRmeRZr5YbhQ2dGAAAAIH8IzAAAAAAgwgjMkC+UMQIAAAD5R2AGAAAAABFGYAYAAAAAEUZghgJAIxQAAAAgPwjMolACrfgBAACAuEJgFqV8ZKEAAACAuBHRwGzMmDHWqlUrK1u2rLt07NjRpk2b5r//5JNPtoSEhKDLDTfcELSOdevWWY8ePaxkyZJWtWpVGzhwoB06dCgCryZ+MY8ZAAAAkD9FLIJq1aplDz/8sDVq1Mh8Pp+NHz/eevbsaYsWLbLmzZu7Zfr162fDhw/3P0YBmCc1NdUFZdWrV7e5c+faxo0brXfv3pacnGwjR46MyGuKPwmR3gAAAAAg5kU0MDv77LODrj/00EMuizZ//nx/YKZATIFXKDNmzLAff/zRPv30U6tWrZodffTRNmLECBs0aJANHTrUihYtelheBwAAAAAUijFmyn5NnDjRdu/e7UoaPW+88YZVrlzZWrRoYYMHD7Y9e/b475s3b561bNnSBWWebt262Y4dO2z58uWZPtf+/fvdMoEXAAAAAIjLjJksXbrUBWL79u2z0qVL25QpU6xZs2buvssvv9zq1q1rNWvWtCVLlrhM2MqVK+3dd99192/atCkoKBPvuu7LzKhRo2zYsGFhfV0AAAAAEDOBWePGjW3x4sWWkpJikydPtj59+ticOXNccHbdddf5l1NmrEaNGnbqqafa6tWrrUGDBnl+TmXe7rjjDv91Zcxq166d79cCAAAAADFZyqhxYA0bNrS2bdu6TFbr1q1t9OjRIZdt3769+3/VqlXuf40927x5c9Ay3vXMxqVJsWLF/J0gvQsAAAAAxG1gll5aWpobAxaKMmuizJmoBFKlkFu2bPEvM3PmTBdoeeWQAAAAACJjw4YNdsUVV1ilSpWsRIkSrgruu+++y/Ixs2fPtmOOOcYlU5TAGTduXIZlnnvuOTvyyCOtePHiLnnz7bffZlhG/Si6dOlipUqVcvHBSSedZHv37rVoFdHATCWFX3zxha1du9YFWLquN6JXr16uXFEdFhcuXOju/+CDD1wrfO1QzX0mXbt2dQHYlVdeaT/88INNnz7d7rvvPrv55pvdGwkAAAAgMrZt22bHH3+8m8pKcxWrm/oTTzxhFSpUyPQxa9ascdNhnXLKKS4pc/vtt9u1117rzvM9b731lhuWNGTIEPv+++9dxZ0aAAYmaxSUnXHGGS5eUNC2YMECu+WWWywxMeryUtExxkw7T8GW5h8rV66cC7i0008//XRbv369a4P/9NNPu06NGgN2wQUXuMDLk5SUZB999JHdeOONLnumaFhj1ALnPQMAAABw+D3yyCPuHH7s2LH+2+rVq5flY1544QW3jAI4adq0qX311Vf21FNPueBLnnzySTfX8dVXX+1/zMcff2yvvvqq3X333e62AQMGWP/+/f3Xvd4W0Syigdkrr7yS6X16E9UEJDvq2jh16tQC3jIAAAAAoaSfakqVaqGq1VTxpmDqoosucuf1RxxxhN10000uqMrMvHnz7LTTTgu6TetQ5kwOHDjgKupUaedRFkyP0WO95M8333zjqvA6derkKvGaNGni5kw+4YQTovZNjXhXRgAAAAAFY8PeclYkMTxDeg7t/acPRPpu5iopHDp0aIblf/31VxszZowrO7znnntcOaGyWGr+pyq3UDZlMh2WgkGND1N5pOY/DrXMTz/95H9e0TY9/vjjdvTRR9trr73mursvW7bMGjVqZNGIwAwAAABAjmnIUWBX88x6O6ip37HHHmsjR45019u0aeMCI5UeZhaYFQQ9r1x//fX+ckc996xZs1y5ozrBR6PoHf0GAAAAIOqkn3Yqs8BMndTTd0rXmLF169Zluu7qmUyHpedRV8fKlSu7PhOhlvGmy/I6uOf2uSONwAwAAABAgVNHxpUrVwbd9vPPP7seEZnp2LGjy2wF0nRYul1UBqn5jwOXUYZM171l1Ea/Zs2auX7uSCMwAwAAAFDg1Blx/vz5rpRx1apVNmHCBHvppZfc1FYeNfFQl3bPDTfc4MaI3XXXXW7M2PPPP29vv/22W5dHY9ZefvllGz9+vK1YscJ1aFcXd69sMSEhwQYOHGj//ve/bfLkye6577//fre+vn37WrRijBkAAACAAteuXTubMmWKC740nZXa4GsqLHVL9GjarMDywnr16rnW9wrERo8ebbVq1bL//Oc//lb5cskll9iff/5pDzzwgGsWouYen3zySVBDEHVx3Ldvn1vP1q1b3Vxnyrw1aNAgat9pAjMAAAAAYXHWWWe5S2bGjRuX4baTTz7ZFi1alOV6NVm0LlnRHGaB85hFO0oZAQAAACDCCMwAAAAAIMIIzAAAAAAgwgjMAAAAACDCCMyQTz72IAAAAJBPBGYAAAAAEGEEZgAAAAAQYQRmyLeEBHYiAAAAkB8EZgAAAAAQYQRmAAAAABBhBGYAAAAAEGEEZnkW3oFVCWFef8GKpW0FAAAAog+BWRTyxdDcYL7Y2VQAAAAgahGYAQAAAECEEZgBAAAAQIQRmCHfmMcMAAAAyB8CsygUS8O2YmlbAQAAgGhFYBataHQIAAAAxA0Cszzw0YqQfQEAYZBYqSL7FQDiFIEZAAAAAERYkUhvAGIfVZcAAADR4c89pS3JioVl3al7ksOyXvyDjFmUSiDcAQAAAOIGgRnyLYF++QAAAEC+EJghX2iXDwAAAOQfgRkAAAAARBiBGfKFxh8AAABA/hGYId+Y1w0AAADIHwKzKOVj9BYAAAAQNwjMkO+OjDQAAQAAAPKHwAwAgCiR9vfWSG8CACBCCMyicN4ut/YYSUPR/AMAAADIPwKzPIuRyOkw8LErAAAAgHwhMAMAAACACCMwi0IJMVQgGOaqTgAAACAuEJihAFDLCAAAAOQHgVmUYh4zAAAAIH4QmCHfaP4BAAAA5A+BGQAAAABEWJFIbwBiHw1AAAAAEA/S0tJszpw59uWXX9pvv/1me/bssSpVqlibNm3stNNOs9q1a0cmY7Z///78PByFpDMj00wDAACgMNu7d689+OCDLvA688wzbdq0abZ9+3ZLSkqyVatW2ZAhQ6xevXruvvnz54c/Y6YNmDhxoosQ169f7yLGUqVKuQixa9eudvXVV1vNmjXztCGIzcYfjC8DAABAYXfUUUdZx44d7eWXX7bTTz/dkpOTMyyjDNqECRPs0ksvtXvvvdf69etX8IHZlClTbNCgQbZz504XBepnBWAlSpSwrVu32rJly+zTTz+1ESNG2FVXXeX+V0qvcIuljFZ4UcoIAACAwmzGjBnWtGnTLJepW7euDR482O68805bt25deEoZH330UXvqqadsw4YN9sorr9j1119vZ599tqujvPjii2348OH2+eef2+rVq618+fL2+uuv53pD8D+xky8DAAAAQhs6dKglJCQEXZo0aZLp7ho3blyG5YsXLx60zLvvvusq9SpVquTuX7x4cYb1bNq0ya688kqrXr26q+475phj7J133snX25RdUBZI2bQGDRrk+jlylDGbN29ejlZ2xBFH2MMPP5zrjUDsIogEAABAZpo3b+4q6zxFimQdfpQtW9ZWrlzpv67gK9Du3bvthBNOcMmhzEoFe/fu7cZ/ffDBB1a5cmVXXqjlv/vuOzcEK78++eQTK126tNsOee6551yJY7NmzdzPFSpUODzNP/bt25fpfRs3brR44DscA6sSYmdfxMimAkDUS6xUMdKbAAAFSoGYMlfeRYFSVhISEoKWr1atWtD9yoQ98MADrnIvM3PnzrVbb73VjjvuOKtfv77dd999rqpv4cKFBfKaBg4caDt27HA/L1261P71r3+54V5r1qyxO+64I8/rzXVgplRgqJSh0oOtWrXK1brGjBnjHqPIWBcNqFODEdHYNe3Qxo0bu7FsderUsf79+1tKSkrQOtKnO3VRgxIcPum/yQAAAEDhpaAk8JJVp/ZffvnF9aZQgNSrV69sx17t2rXLjdVS98OePXva8uXLc719nTp1srfeesvFE2pWqNhAyaWTTz7ZCoICMGXHvBjorLPOspEjR7psmRfLHJZ5zPSCOnToYMOGDXNNQJROvPnmm+3tt9+2hx56KFfrqlWrlit9bNSokcu8jB8/3r0BixYtctf/+OMPe/zxx90LV5eTG264wd02efLkoPWMHTvWzjjjDP91RcSxLrba5QMAACAa7NhZ3BJTg8dlFZS0Pf+cn6afq0ut4jWeLL327du7cWNKtKiyTvHDiSee6BoHlilTJsPyjRs3tldffdUlbpSMURygIEvBmeKGnFJccskll7hxaMrYlSxZ0jUzbNiwoRWEokWLuvnLRGWaKp2UihUr+jNphyUwe/75561Hjx527bXX2kcffeR2smosv/32W2vRokWu1qUGIoEU2CmLpt7/ffv2DRqkpwF0uv+KK66wQ4cOBdWnKhBTqrPQiKEe9LGzpQAAACgImjZL1W6eYsWKhVyue/fu/p8VbClQUzZMgZPO9dPr2LGju3gUlKnpxosvvui6vufU/fff78aYKWhS6eR7773nxphpyq+WLVtafmlsmUoWjz/+eBcDKTsnP//8c64CyAKZYFo7+fzzz7evv/7apSMfeeSRXAdl6aWmpro0ozJwgW9IIEXOOgjSDxpUxk47XXWkirKzGwOmdGv6FCzyjtweAABA/PCGIXmXzAKz9JRM0XxgmpA5p90N27Rpk+PlRV3in332WRcTnHrqqda6dWuX0Tv22GNdqWFB0PoVj6iKT0klNUAUlTEGVvGFPWOmF3v55Ze7NpTTp0+3OXPm2DnnnGO33Xaby2iFmmwtKxowp0BMdZ/KvCnN6NVsBvrrr79cpHzdddcF3a5W/V26dHEpSs0vcNNNN7naVI1Hy8yoUaNcKjU/KDVE1GGsHwAAiGI6R1csoQYeOU3cLF261DXWyCmvxDAxMTj/lJSU5MabFQT1vlDlYHqaXiw/ch2YHX300a6UUUGZol7NfK2dpdrKmTNnuvFhuaFaUjUTUTZMUWefPn1csBcYnCmjpefUbenrV5Wq9CiiVsbtscceyzIw08RvgR1TtP70tbLZ8VHEh2gTQyWwAACg8NNEyxq6pPJF9YlQ5koB0mWXXebuV/ygbJOSJl7CRb0sNBZMpYg6p1efCQ2h8qihhyr2tD7xWut7XRw1T5oer3mXNUZN48xUyqg4JVQwlVcKMNXnQv+PHj3aqlat6jJmCto0RcBhKWXUGDOVHAY22FD9pwIydWzMy+A57by2bdu6N0XpRr04z86dO11KUAMElU3LLiOn2tXff/89y+4wSremT8ECAAAAKDg6J1cQpkSMxngpSFIviSpVqrj7FWAFTre1bds2NzeZxpUp8aPkiVrfByZsNDeZkjFK2sill17qrr/wwgvuumKFqVOnuudQUKixba+99pprMpibzFtWlETSWLVvvvnGTXitTKD88MMPLvg8bBmzzFKPCpxeeeUVyy+lGL2gSm9Gt27dXCClNyH9zN+hKPumSd1yWuuK/CNPAwAAgPSym8Jq9uzZGUoBn8qmHPCqq65yl6yo43tgE8GCdvfdd9uDDz7oKvACu0tqeJXGnx22wMxLGT7zzDO2YsUKd11R7S233OJSh7mhkkI1ElHKT5kxzcqtN0hlkgrKunbt6upEX3/99aAmHYqAlQb98MMPbfPmzS7lqaBNKUrNIaC0aUxjrBAAAAAQlTTuTXFLeipnVF+MwxaYKfpUylCdTbzuiUpJKp2nqPiCCy7I8bq2bNniakuVwixXrpxLNSoo07g1BWhKD0r6OQc0qduRRx7pUpXqrjJgwADXiVHLPfnkky4FGutiZQwbHRkBAAAQT8qXL+/il3r16gXdrqFdXofGwxKY3XXXXS7TpcF5gVRPqftyE5hlVfqoiayza3uvsWf5aUkJAAAAALmhJNWgQYNs0qRJlpCQ4IZiaRoxVe15k00fluYfig5DPaEmfg4cvIf4kV0ADQAAABQWI0eOdEO41NVdjT/UnOSkk05yDRHvu+++w5cxUyZLs2anLy/86quv7MQTT8zzhgAAAABAtFNX+ZdfftkeeOABN95MwZk6Q6rpSH7kOjDTZNJK3S1cuNA13fDGmCmVp0mb1T0xcFnkUQwloWJoUwEAAIACoYyZLt5E2Gr3r+7why0wu+mmm/zzmekS6j5RvaU2EoWb3mcAAAAgXtx+++2u8WHfvn1dvNO5c2c331rJkiXdJNaqMDwsY8w0uC0nF4IyAABy+Tf2763sMgCIcpMnT7bWrVu7nzV916+//mo//fST6xR/77335nm9uQ7MAAAAACBe/fXXX1a9enX389SpU+3iiy+2o446yq655hpX0hjWwCy7WbsDrV+/3rWLBAAAAIDCplq1avbjjz+6CsFPPvnEzcEse/bssaSkpPAGZmPGjLGmTZvao48+aitWrMhwf0pKiosWL7/8cjvmmGPs77//zvMGAQAQrxIrVYz0JgAAsnH11Ve7LFmLFi1cv4XTTjvN3f7NN9+4Nvphbf4xZ84c123xmWeecZNLlypVykWKxYsXd91HNm3aZJUrV7arrrrKli1b5u5DPiXEzhxmMbKpAAAAQL4NHTrUBWWqFLzooousWLFi7nZly+6+++7wd2VU63tdVFOpOct+++0327t3rwvI1Ldfl8REhqzFIzozAgAAIJ5ceOGFQde3b99uffr0ydc6c90uX4HYueeem68nRfYSYiQPxRxmAAAAiCePPPKIHXnkkXbJJZe46yprfOedd6xGjRpueFerVq3ytF5SXMi32AghAQAAgPx74YUX3MTSMnPmTHeZNm2anXHGGXbnnXcevowZDgMfeSgAAAAgGqm/hheYaUJpZcy6du3qsmjt27fP83rJmCHfzT8AAACAeFGhQgXX+EPULt/ryqjzYrXQzysyZlE6BixWygMVltH8AwAAAPHi/PPPd9OENWrUyE0T1r17d3f7okWLrGHDhoc/MDtw4ICtWbPGGjRoYEWKxFt8R5YIAAAAiEdPPfWUK1tU1kzzPJcuXdrdvnHjRrvpppvyvN5cR1Sa0frWW2+18ePHu+s///yz1a9f3912xBFH5Kt3PwAAAABEs+Tk5JBNPgYMGJCv9eY6MNME0z/88IPNnj3bdR7xqLZSk60RmMVZPk4TTCfESuFl4cZwPwAAcHB3UUtMKxqWHZG2N40dHODHH3+0devWuUrCQJr7+bAEZu+995699dZb1qFDh6AT8ubNm9vq1avztBHIiGAHueUzBckEaAAAAOH066+/2nnnnWdLly515+xeMzzv/D2vDUBy3ZXxzz//tKpVq2a4fffu3QQTBYhuhyisk5IDAADEsttuu83q1atnW7ZssZIlS9ry5cvtiy++sGOPPdZVFeZVrgMzPeHHH3/sv+5Fhv/5z3+sY8eOed4QAPlHOSMAAEB4zZs3z4YPH26VK1e2xMREdznhhBNs1KhR1r9//zyvN9eljCNHjnQtIVVTeejQIRs9erT7ee7cuTZnzpw8bwhiF9m96MBQPwAAgPBTqWKZMmXczwrO/vjjD2vcuLHVrVvXVq5cefgyZooGFy9e7IKyli1b2owZM1xpoyLHtm3b5nlD8D8xVZBGNAAAAIA40qJFC9cMUdq3b+9a5n/99dcui6Zu9XmVpwnINHfZyy+/nOcnBQAAAIBYdN9997n+GqJg7KyzzrITTzzRKlWq5JokHrbArEuXLta5c2cbMmRI0O3btm2zCy64wD777LM8bwwAAAAARLNu3br5f27YsKH99NNPtnXrVqtQoUK+miHmOjBTpxG1hly0aJG98cYbVqpUKXe7+vfHzxizmCo2BAAAABAG69evd//Xrl073+vK9Rgz+fTTT23Tpk1uLrO1a9daPNKcUQAAAADiy6FDh+z++++3cuXK2ZFHHuku+lkljgcPHjy8gVmNGjVcdkzNP9q1a5evfv2IbeQOAQAAEE9uvfVWe+mll1zTD1UR6qKfX3nllcPbLt+rmyxWrJhNmDDBHnzwQTvjjDNs0KBBed4IZBRL+Tja5QMAACBeTJgwwSZOnOimEPO0atXKlTNedtllNmbMmMMTmKU/CVfKrmnTptanT588bQBiW34GOAIAAACxplixYq58Mb169epZ0aJFD18p45o1a9xEaoHUjXH+/Pn26quv5nlDAAAAACDa3XLLLTZixAjbv3+//zb9/NBDD7n78irXGTPNaJ3ZRGu6oACQhQLHDQAAQFTSmLJZs2ZZrVq1rHXr1u42TTitLvWnnnqqnX/++f5l33333YINzLTycePGWdmyZYOeKJTcPDkKh1gaD1eopSszBgAAQMErX768qxgMVBDt8nMUmKn9ozeWSD8DHkaYAQAAIJ6MHTs2LOstktsnD9eGAAAAAEC8ynXzj71799qePXv813/77Td7+umnbcaMGQW9bXEtliawpl0+AAAACrMzzjjDNTvMzs6dO+2RRx6x5557LvzNP3r27OnGmd1www22fft2O+6441xbyL/++suefPJJu/HGG3O9EYhdtMsHAABAYXfRRRe5cWUa1nX22WfbscceazVr1rTixYvbtm3b7Mcff7SvvvrKpk6daj169LDHHnss/IHZ999/b0899ZT7efLkyVa9enXXmeSdd96xBx54IC4CM4KRYLGT2wOA6Jb299ZIbwIAIIS+ffvaFVdcYZMmTbK33nrLXnrpJUtJSfHHBs2aNbNu3brZggUL3BzPeZHrwExljGXKlHE/q3xR2bPExETr0KGDK2uMH2EOR2Ik2qH5BwAAAOJlYukrrrjCXUSBmYZ5VapUyZKTkw//GLOGDRvae++9Z+vXr7fp06db165d3e1btmxx7fSRfwQ7AAAAiHVDhw512aTAS5MmTbJ8zKRJk9wyKhFs2bKlKw30HDx40AYNGuRuL1WqlCsl7N27t/3xxx8ZKvxOP/1019ZeQdN1111nu3btKvDXp7JGVQ8WRFCWp8BM5Yp33nmnHXnkkda+fXvr2LGjP3vWpk2bAtkoAAAAALGvefPmtnHjRv9F47AyM3fuXLvssstc2aCGSp177rnusmzZMn/lnoKu+++/3/2v+ZNXrlxp55xzjn8dCtJOO+00l0z65ptv7JNPPrHly5fbVVddZdEu16WMF154oZ1wwglux3ozXYtmuT7vvPMKevsQA5jXGAAAAKEUKVLEZZVyYvTo0a774cCBA931ESNG2MyZM+3ZZ5+1F154wWWodD2Q7lMzwnXr1lmdOnXso48+chksdUXUcCvRY1u1amWrVq1yAVu0ynXGTLRzlR3zXqxoh2SXmkTh8//zjgMAACBO7NixI+iyf//+TJf95ZdfXMlh/fr1rVevXi6Aysy8efNctiuQGmro9sxonJdKJFW2KNoWdYwPjFNKlCjh/s8qWxezgRkAAACA6JO0O8mSdoXpsjvJPUft2rVd9sq7jBo1KuS2aNjTuHHjXDnhmDFjbM2aNXbiiSe6ub5C2bRpk1WrVi3oNl3X7aHs27fPjTlT+aPX66JLly5uebWrP3DggGtlf/fdd7v7VPFXqEoZAQAAAMQvNQEMbPqnboWhdO/e3f+zSgkVqNWtW9fefvttN44sPw4ePGgXX3yx+Xw+F/QFjmkbP3683XHHHTZ48GBLSkqy/v37uwAvMIuWX5rPWVOHrV692pVeVqxY0Y170/McccQReVongRkAAACAHFNQlpdu7Co3POqoo9xYr8yGS23evDnoNl1PP0bNC8o0Vddnn32WYVsuv/xyd9Fj1b1RpY5PPvmkK6csCEuWLHEll8oWrl271vr16+cCMzUjUanma6+9lqf15jhsDGxVCQAAAAC5oZb1yjDVqFEj5P0dO3a0WbNmBd2mZh9eF/jAoExj1z799FPXDj8zyl6VLl3aTQit9vtqoV8QlI1Tl0dtg9brOfPMM+2LL77I83pzHJhpIulwzQGA2EVHRgAAAISiKbbmzJnjskpqha8O7iot1Jgw0RxkKjf03HbbbW482hNPPGE//fSTmwftu+++s1tuucUflKlDvG574403LDU11Y0n00XjyQI7Naqs8Oeff3bdGfV4jYPzGoTk14IFC+z666/PcLtKGDMbD1eggZnmAdBGqD40P5EgCh86MwIAACC933//3QVhjRs3dlkuZbfmz59vVapUcfer7C+wIUenTp1swoQJ9tJLL7lpuTSG67333rMWLVq4+zds2GAffPCBW+/RRx/tMm/eRYGf59tvv3XZMU1ErXW9+OKLbpxZQdGYOnWjTE+BoPfawjrGTDtHgdmDDz5oXbt2tZtvvtnuvfdeNzdBoLzUmyKYjx0CAACAGDdx4sQs7589e3aG2y666CJ3CeXII490zT6yk9cxXjmlCa2HDx/umpiIxrApyFSHyAsuuCDP681VaxIFYUopKlLVBHCKCCtUqOAuSg3q//jBBF4AAABAvHniiSfc8K6qVava3r17rXPnzm7i6jJlythDDz2U5/Xmuiujuo3ceOONdtJJJ4XMmMWDnETq8YI9AQAAgHhSrlw515REE1arQ6OCtGOOOSbD5Nhhy5ipV7/aTl555ZV2zz33uNaUp556qosQAy+5oTkHNGbNa7mpjivTpk0LmjROJZOqR1VHFaUG07fQVNqwR48eVrJkSRe1ah6BQ4cOWcyLoYRcDG0qAES1xEoVI70JAIAcOuGEE+ymm26yu+66K99BmeQ43dWsWTOrU6eO63CiAXwFoVatWvbwww9bo0aNXBZKk8H17NnTFi1a5CaHGzBggH388cc2adIkF5mqo4q6Q3799dfu8erEoqBMcxtowJ8GD6q7S3Jyso0cObJAthFZI3sIAACAeLNgwQL7/PPPbcuWLZaWlhZ0n+ZMC2tgpmjQmz27oJx99tlB11WTqSyaurUoaHvllVdcZ5YuXbq4+8eOHWtNmzZ193fo0MFmzJhhP/74o5vDQPMUqDvLiBEj3MA7jYUrWrRogW0rMqcBjwAAAEA8GDlypN13330uWaUYJPBcOD/nxTkOzPTk4aTslzJju3fvdiWNCxcudHMVBKYFmzRp4rJ28+bNc4GZ/lcbTO0QT7du3dwYuOXLl1ubNm3Cus0AAAAA4svo0aPt1VdfdZNMF6SId+5YunSpC8Q0nkzjyKZMmeLKJhcvXuwyXuknglMQ5k3cpv8DgzLvfu++zOzfv99dPKHmIYi0BEZuAQAAAFEnMTHRjj/++IJfr0WYUoAKwjSBtTJdffr0ceWJ4aSZvzVmzbvUrl3bokoMdX2MnS0FAAAA8k99MJ577jkraBHPmCkrpr7/0rZtWzeQTunBSy65xA4cOOC6QQZmzdSVUc0+RP9rZu9AXtdGb5lQNFbujjvuCMqYRV1wBgAAACDq3Hnnna4BYYMGDVylnxoPpp9eLCYzZumpq4nKDBWk6UXOmjXLf9/KlStde3yVPor+VymkuqF4NKeAWu9rJ2WmWLFi/hb93gUAAAAAstO/f3/XkfGoo45y03oFVuLpEvaMWWCGKSu5aQ+pzFX37t1dQ4+dO3e6DoyzZ8+26dOnuxfVt29f97wVK1Z0wdOtt97qgjE1/pCuXbu6AExzqz366KNuXJmalGjuMwVfODzoyQgAAIB4MX78eHvnnXdc1qwg5Tgw09xi2clte0hlujTvmOYfUyCmyaYVlJ1++unu/qeeesoNrtPE0sqiqePi888/73+8Wvd/9NFHbmyaArZSpUq5MWrDhw/P1XYAAAAAQE4oaaQyxoKW48BM6bqCpnnKslK8eHE3sC6rwXV169a1qVOnFvi2AQAAAEB6mi95yJAhbo7lkiVLWsSbf/z111/u/8qVKxfYxgAAAABANPv3v/9tq1evdtN0HXnkkRmaf3z//ffhD8zUIfHee++1t956y7Zt2+Zuq1Chgl166aX24IMPZphzDAAAAAAKk3PPPTcs681xYLZ161Y3jmvDhg3Wq1cva9q0qbtdc46NGzfOdU+cO3euC9QQP3wxNOcaAAAAkF8qY4xoYKaGGppzzEvbpb9PHRL1vxp2AAAAAADCMI/Ze++9Z48//niGoMybzFnt6qdMmZKLpwYAAACA2KKu8eoOn9kl7BkztbRv3rx5pve3aNHCzSMGAAAAAIXVlHTJqIMHD7qpxTS/2bBhw8IfmKn74tq1a61WrVoh71+zZo3r6R8vEsI8rXIsTdqc2/nrAAAAgFjVs2fPDLddeOGFLomlJol9+/YNb2CmyZ3VkXHmzJlurFkgTf58//332xlnnJGnjUBGsdRSgwYgAAAA0SFpR6IlHcjxaKVcSd0XnvUWFh06dLDrrrvu8DT/OPbYY61Ro0Z28803W5MmTdwJ+YoVK+z55593wdl///vfPG8IAAAAAMSivXv3uvnNjjjiiPAHZiphnDdvnt100002ePBgf5ZEZWynn366Pfvss1a7du08bwgAAAAARDtNDxY4lEdx0c6dO61kyZL2+uuv53m9uZpgul69ejZt2jQ3ufQvv/zibmvYsGFcjS0DAAAAEL+eeuqpoMBMXRqrVKli7du3z9eczrkKzDx6wuOOOy7D7ZMnT3YD3wAAAACgMLrqqqvCst5cBWaHDh2yn376yTX/OOqoo/y3v//++/bAAw+4+wjMAAAAABQmS5YsyfGyrVq1Cm9gtmzZMjvrrLNs/fr1/jaRY8aMsYsvvtjd169fP/v444/ztBEAAAAAEK2OPvpoV76YXTdyLZOamhrewGzQoEFuPJmafLz55pvuoo6M6tP/ySefWIkSJfK0AQAAAAAQzTRnc7jlODBbsGCBzZgxw0WLJ554ogvM7rnnHrvyyivDu4UAAAAAEEF169aNnsDsr7/+spo1a7qfy5UrZ6VKlXKTqAEAAABAPFm9erU9/fTTroJQmjVrZrfddps1aNAgz+vM8fTdqpdUf/4dO3ZYSkqKu66J1HQ98AIAAAAAhdX06dNdIPbtt9+6Rh+6fPPNN9a8eXObOXNm+DNmGugW2IlR19u0aRN0PT+D3RCbAudwAAAAAAq7u+++2wYMGGAPP/xwhtvVl+P0008Pb2D2+eef5+kJCiufZd2RBQAAAEDhs2LFCnv77bcz3H7NNde48sa8ynFg1rlz5zw/CQAAAAAUBlWqVLHFixdbo0aNgm7XbVWrVj08E0wDoZA7BAAAQLzo16+fXXfddfbrr79ap06d3G1ff/21PfLII3bHHXfkeb0EZtGIcVsAAABAVLr//vutTJky9sQTT9jgwYPdbepeP3ToUOvfv3+e10tgFqViZQwbrT8AAAAQb83vBgwY4C7qWi8K1PIrx+3yAQAAACDePfjgg7ZmzRp/QFYQQVmBBWZqlT9t2jS78MILC2J1AAAAABCVJk2aZA0bNnTjy55//nn766+/Ih+YKVJUjWWdOnXsvPPOs3379hXIRiG2KDAHAAAA4sEPP/xgS5YssZNPPtkef/xxN76sR48eNmHCBNuzZ8/hC8z2799vb7zxhnXp0sUaN25sI0eOdN1HtmzZYh999FGeNwQAAAAAYkHz5s1dHKTOjJrv+cgjj7Tbb7/dqlevHv7AbOHChXbTTTe5J9PEaeeee66tX7/eEhMTrVu3bla2bNk8bwRC8MXO4McY2VQAAACgwJUqVcpKlChhRYsWtYMHD4Y/MGvfvr0VK1bM5s+fbwsWLHCtIKtVq5bnJwYAAMHS/t7KLgFQKD388MPuC31llTIzbtw4t0zgpXjx4pkuf8MNN7hllDQK9NBDD7nxXyVLlrTy5ctbOGhIl55HmbNjjz3WFi1aZMOGDbNNmzaFv13+qaeeaq+88oorWbzyyitdlkw7AgAAAAAyo6TOiy++aK1atcp2J5UtW9ZWrlzpv55ZvDFlyhSXMNL4rvQOHDhgF110kXXs2NHFLwWtQ4cO7jXp9Vx99dV22WWX2RFHHJHv9eY4MJs+fborXRw7dqzdeOONtnfvXrvkkkvcfQRoAAAAANLbtWuX9erVy15++WXXZj47CQkJ2Y7T2rBhg916660uPlHTjfSUufIycOGghNWrr75qzZo1K9D15qr5R+3ate2BBx5wqbv//ve/9ueff1qRIkWsZ8+eds8999j3339foBsHAAAAILrs2LEj6KLmgJm5+eabXfB02mmn5TiQq1u3ros7FGMsX7486P60tDRXvTdw4EBXRhgJKmEs6KAsVxmz9E4//XR32bZtm73++usuanzkkUcsNTW1YLcQAAAAQI4k7zZLOhSenZX4//GXgqZAQ4YMsaFDh2ZYfuLEiS5xo7K/nGjcuLGLKVQimJKS4lrRa6yYgrNatWq5ZRRvKDGkfheFTZ4DM0+FChVcKlEXMmYAAABA4abhTYEd2dUgMNQyt912m82cOTPLBh6BOnbs6C4eBWVNmzZ149NGjBjhusSPHj3axRyFcShVrkoZlTpUFHvWWWdZixYtrGXLlnbOOefYa6+95iYZPuaYY8K3pQAAAAAiTkFZ4CVUYKYgSk0DFR8ow6XLnDlz7N///rf7OSdVdsnJydamTRtbtWqVu/7ll1+6ddapU8e/zt9++83+9a9/uXnE4iZjpsBLQdjUqVOtdevWLijTbStWrLCrrrrK3n33XXvvvffCu7WIOjoGAAAFI7FSRVrmAygU1CBj6dKlQbepg2GTJk1s0KBBlpSUlO06UlNT3TrOPPNMd11jy9KPVVOneN2udcdNYKauJl988YXNmjXLTjnllKD7PvvsMzfhtDJnvXv3Dsd2xp/Cl50FAABAnChTpoyrsEs/EXOlSpX8tytuUJv5UaNGuevDhw93regbNmxo27dvt8cee8xlxK699lp3vx6rS/qsmro4anyaZ926dbZ161b3v4K7xYsXu9u13tKlSxfYa9yzZ497DrXnD5STaQHyFZi9+eabrvNi+qBMunTpYnfffbe98cYbBGYAAAAAsqWgJjHxfyOrtm3bZv369XOTNKuPRdu2bW3u3Lm57oCoLvLjx4/3X1c5pHz++ed28skn5/udUWd6ZeimTZsW8v68NkPMcWC2ZMkSe/TRRzO9v3v37q5mFPGH5B4AAACyM3v27CyvP/XUU+6SG2vXrg1Z6ReuOczk9ttvdxm9b775xgV6mux68+bNbp62J554Is/rzXFgpnRgtWrVMr1f9ynKBQAAAIDC6rPPPrP333/fjj32WJfx07xrmkZMjVBUlhlq0usC7cqolJw6n2RGA/gOHQrTpAkAAAAAEAV2795tVatWdT+r5FKljaLmiPmZPixXXRnVfTFUO0zJasZvAAAAACgMGjdubCtXrnQt+tWtXvOs6ecXXnjBatSoEf7ArE+fPtkuQ0fGgpMQQyO3CuMEfzGJ9wEAACDsNHH2xo0b3c9DhgyxM844wzVBLFq0aL7GtuU4MBs7dmyenwS5FENzg8XOlsaBGDpuAAAAYtUVV1zh/1mdI9XS/6effnITX1euXDnP683xGLOcmDx5ckGuDgAAAACiiuZb0xxmnpIlS9oxxxzj5mnTfYclMFNzj2XLltnPP/8cdLu6kqi+slevXnneEMQuChkBAAAQL4YNG2a7du3KcLuCNd0X9sBMAZlmy1YA1rRpUzv//PNdv/7OnTvbNddc4+YxW716dZ43BLFJTWEAAACAeDr/TQgxtv+HH36wihUrhn+M2aBBg1xg9uyzz9qbb77pLitWrLC+ffvaJ598YiVKlLB4EkvNOcKJsAwAAADxoEKFCi4g0+Woo44KCs40tZiyaDfccEP4A7MFCxbYjBkz7Oijj7YTTzzRBWb33HOPXXnllXl+cmQulsI+ujICAACgsHv66addtkzVgipZLFeunP8+dWRUy/yOHTuGPzD766+/rGbNmu5nbYQGt3Xo0CHPT4zMkYUCAAAAoos3fVi9evWsU6dOlpycXKDrL5KbrMjOnTutePHi/rrKvXv32o4dO4KWK1u2rBV+hE7/2xXsCwAAAMSPzp07+3/et2+fHThwoEDioRw3/1AwplpK1VZqUJtqKNu0aeOu61K+fHn3f26MGjXK2rVrZ2XKlLGqVavaueee62bR9qxdu9Zfx5n+MmnSJP9yoe6fOHGixSpfjAV+lDJGT4zMHNMAAADhpe6Lt9xyi4tfVEXoxUPeJewZs88//9wK2pw5c+zmm292wZla8WvMWteuXe3HH390L7J27dr+WbU9L730kj322GOuC2T6CbA167ZHgSLCL7ZCyMIt7f8z2XTKBAAACJ+BAwe62GjMmDGu38Zzzz1nGzZssBdffNEefvjh8AdmgSm7gqJujoHGjRvnIs+FCxfaSSedZElJSVa9evWgZaZMmWIXX3yxlS5dOuh2BWLpl41lZKGQt5QZ+w0AACCcPvzwQ3vttdfs5JNPtquvvto1RlT3+rp169obb7yR57mdc1zKqLFkObnkR0pKivs/s/7/CtgWL17sWvSnp8xb5cqV7bjjjrNXX32VrMFh4sYbHq4nQ/YZM94NAACAsNq6davVr1/fP55M1+WEE06wL774IvwZM2WkssrieA1B1MM/L9LS0uz222+3448/3lq0aBFymVdeecVNbq0uKIGGDx9uXbp0sZIlS7qW/jfddJMbA9e/f/+Q69m/f7+7ePIbUIZDLAU7ZPeiJ2GWmKjfwUhvCQAAQOFVv359W7NmjdWpU8eaNGlib7/9tksOKZOWn+FUER1jlj7jtWzZMvvqq69C3q8OkBMmTLD7778/w32Bt6khye7du904tMwCMzUd0dwD0SyWxm4xpik66HuTtLRYOnIAAABiz9VXX20//PCDG+p1991329lnn23PPvusHTx40J588snYHGPmUVeTjz76yKX+atWqFXKZyZMnuw4ovXv3znZ97du3txEjRrisWLFixTLcP3jwYLvjjjuCMmZqNILcc80m2HFRIdG9F7wbAAAA4TRgwAD/z6eddpr99NNPbsiVxpm1atUq/IFZuDItt956q2voMXv2bDdZW2ZUxnjOOedYlSpVsl2vxqGpVWWooEx0e2b3ATGdMiMuAwAAOKzU9EOX/MpxYJaYmJjtWCLdr7b3uSlfVHni+++/7+Yy27Rpk7u9XLlyVqJECf9yq1atctm0qVOnZliHajk3b95sHTp0cJNfz5w500aOHGl33nmnxeoIMDVwiJXywFgaCxcPGTNKGQEAiG9Fd5klBc93XGBSw7TeWJKWluY6yb/77rv+OZeVXLrwwgtd6/z89F7IcWCmrFZm5s2bZ//+97/dhuaGev+LWk2mn5Psqquu8l9Xl0WVOGqOs/SSk5Pd3AFKKSqYUQpRtZ39+vXL1bYg72IliCzsmFwaAAAgvOe8quBTsqh169bWsmVLd9uKFStc7KJg7b333gt/YNazZ88Mt61cudINeFPWSv361R0xHCf0yoDpEoomlQ6cWLowiKksFNEAAAAA4sC4ceNcFd+sWbPslFNOCbrvs88+s3PPPdfNb5aTnhj5mscs0B9//OEyUooSVbqoMV3jx48vkNpKAAAAAIg2b775pt1zzz0ZgjLR1F1KWGmC6bxKzO0E0IMGDXLlgsuXL3fRorJlmc07hsJP2T1KGQEAAFDYLVmyJMtKve7du7s2+mEvZXz00UftkUceserVq7toMVRpYzwJd1vyWBm1xeTSAAAAiAdbt261atWqZXq/7tu2bVv4AzOl5tQpUdkylS3qEooGvSG+xEoQCQAAAORVamqqFSmSefiUlJSUqw71eQ7MNIiN7MhhQkMNAAAAIKpo+I66L2Y2H/L+/fvztf4iuelCAsR0B0kAAAAgj/r06ZPtMnntyJirwAzIDM0/AAAAUNiNHTs2rOvPU7t8IBAlrgAAAED+EJghX2j8AQAAAOQfgRkAAAAARBiBWTTyxVYeigYgAAAAQP4QmAEAAABAhNGVMQ+27l9uOw+WLPh3IwbRkREAAADIPzJmebDn0Cbbn7a7AHY/AAAAABCYRa1YGbel0XC0ywcAAADyh4wZAAAAAEQYgVkUiq2ejAAAAADyi8AMcdXaHwAAAIhGBGbIN8aYAQAAAPlDYIZ8o2U+AAAAsvLwww+7L/Nvv/32LJebNGmSNWnSxIoXL24tW7a0qVOnBt1/1VVXufUEXs444wz//WvXrrW+fftavXr1rESJEtagQQMbMmSIHThwIOrfIOYxAwAAABA2CxYssBdffNFatWqV5XJz5861yy67zEaNGmVnnXWWTZgwwc4991z7/vvvrUWLFv7lFIiNHTvWf71YsWL+n3/66SdLS0tzz9ewYUNbtmyZ9evXz3bv3m2PP/64RTMyZrmUlFDMEi05PO8GAAAAUIjs2rXLevXqZS+//LJVqFAhy2VHjx7tgq6BAwda06ZNbcSIEXbMMcfYs88+G7ScArHq1av7L4Hr9YK2rl27Wv369e2cc86xO++80959912LdgRmOZBgxax26dOtTeU77OjKt1ubKnfYyVX7WJ2SLcP/DgEAAABRZMeOHUGX/fv3Z7rszTffbD169LDTTjst2/XOmzcvw3LdunVztweaPXu2Va1a1Ro3bmw33nij/f3331muNyUlxSpWrGjRjlLGHKhc+gJbt2+3/bT9DatUrLkd8u2xpbv22FFl2ltyYjFbveu78L9TAAAAQDaK7vRZUtHwdM1OPfDPemvXrh10u8ZwDR06NMPyEydOdGWIKmXMiU2bNlm1atWCbtN13R6YETv//PPdGLLVq1fbPffcY927d3fBW1JSUoZ1rlq1yp555pmoL2MUArMcSE6sYhv3zHQ//35oszUp39tSDk63hVs/thOqXEpgBgAAgLixfv16K1u2bMgxXoHL3HbbbTZz5kzXyKOgXHrppf6f1RxE49bU4ENZtFNPPTVo2Q0bNrhA7qKLLnLjzKIdpYw54vOPKyuSUNISEv7ZbWmW6i5xLSEh0lsAAACAw0hBWeAlVGC2cOFC27JlixsjVqRIEXeZM2eO/fvf/3Y/p6ZmPIeuXr26bd68Oeg2XdftmdE4ssqVK7vMWKA//vjDTjnlFOvUqZO99NJLFgvImOXArgOLrGmFPrbr4O9WpuiRtnnPN+72ooklwv3+AAAAADFH2aulS5cG3Xb11Ve7VviDBg0KWXbYsWNHmzVrVlBLfWXcdHtmfv/9dzfGrEaNGkGZMgVlbdu2dY1AEhNjIxdFYJYDO/Z9aX/69lnJIlXt750/2q6D61TxagfS9tpXf04M/7sEAAAAxJAyZcoEtbiXUqVKWaVKlfy39+7d24444gjXHl9U+ti5c2d74oknXMMQjVH77rvv/BkvdXgcNmyYXXDBBS6LpjFmd911l2uLryYhXlB28sknW926dd24sj///NM8WWXeogGBWQ7tPLjWXTzJCcXsoC/zDjQAAAAAMrdu3bqgbFanTp3c3GX33Xefa+rRqFEje++99/yBnLJsS5YssfHjx9v27dutZs2ari2+2up75ZTKsKmsUZdatWoFPZ/PF56mKAWFwCyPjq9ysc3e8t+CfTcAAACAQkoNOrK6LmrUoUsoJUqUsOnTp1tWrrrqKneJRQRmOVC7/H1WNi14PNmutDJ2WrVr3c+fbv5PeN4dAAAAAHGBwCwHDqRutG37D9rGPXP9t1Urc73N/zs8M4jT5xAAAACIL7HRoiTCNu98xfal/m31yp5lCQlJdiAtxXyWZntTd7oLAAAAAOQHGbMc2rz3W0s58KvVK9PDtu1fma+dDgAAAACByJjlwr7Uv+yn7a9bUkJx25u6KzcPBQAAAIBMkTHLNZ/9secLW0XWDAAAAEABIWOWT1WLHVkw7wQAAACAuEVglk9Vi9crmHcCAAAAQNwiMMuDIgklrVLRWlYssaQtS/m84N8VAAAAAHGFMWY5ULnURbbu4Ld2yLfHyiTXtQZlz7M/DhyyEkllXGC2ed+a8L9TAAAAAAotArMcSE6q7oIyqVnqBFuZ8qYt3W1WIqmsHVOhO4EZAAAAgHyhlDEHEhL+F78mJiTb3kOb3c97U3dYQkJC/t4BAAAAAHGPwCwH9h1cZbVLn26Jlmw7Dqy1isWaudurFKtrB9L2xf1BBAAAACB/KGXMga17ppoVvdhaV77VDqXttaIlO1jFUsXtr/2/29Ltn+XzLQAAAAAQ7wjMciTV1u/61Dbsmm3FkiqYJSTaT3uK2UHf/nC/PwAAAADiAIFZLqTZIdub+qf7+aCvWrjeEwAAAABxhjFmAAAAABBhBGYAAAAAEGEEZgAAAAAQYQRmAAAAABBhNP/Ig/JFG1np1CTbdWhbwb8jAAAAQB4V3ZFqRZJTw7L/Dh0Mz3rxDzJmeVA6ubaVSCqbl4cCAAAAQHQFZqNGjbJ27dpZmTJlrGrVqnbuuefaypUrg5Y5+eSTLSEhIehyww03BC2zbt0669Gjh5UsWdKtZ+DAgXbo0KHD/GoAAAAAIAZLGefMmWM333yzC84USN1zzz3WtWtX+/HHH61UqVL+5fr162fDhw/3X1cA5klNTXVBWfXq1W3u3Lm2ceNG6927tyUnJ9vIkSMP+2sCAAAAgJgKzD755JOg6+PGjXMZr4ULF9pJJ50UFIgp8AplxowZLpD79NNPrVq1anb00UfbiBEjbNCgQTZ06FArWrRo2F8HAAAAABSaMWYpKSnu/4oVKwbd/sYbb1jlypWtRYsWNnjwYNuzZ4//vnnz5lnLli1dUObp1q2b7dixw5YvX34Ytx4AAAAAYrwrY1pamt1+++12/PHHuwDMc/nll1vdunWtZs2atmTJEpcJ0zi0d999192/adOmoKBMvOu6L5T9+/e7i0dBHAAAAABYvAdmGmu2bNky++qrr4Juv+666/w/KzNWo0YNO/XUU2316tXWoEGDPDcdGTZsWL63GQAAAAAKTSnjLbfcYh999JF9/vnnVqtWrSyXbd++vft/1apV7n+NPdu8eXPQMt71zMalqRxSZZPeZf369QX0SgAAAAAgxgIzn8/ngrIpU6bYZ599ZvXq1cv2MYsXL3b/K3MmHTt2tKVLl9qWLVv8y8ycOdPKli1rzZo1C7mOYsWKufsDLwAAAAAQl6WMKl+cMGGCvf/++24uM29MWLly5axEiRKuXFH3n3nmmVapUiU3xmzAgAGuY2OrVq3csmqvrwDsyiuvtEcffdSt47777nPrVgAGAAAAANEuohmzMWPGuFJCTSKtDJh3eeutt9z9anWvNvgKvpo0aWL/+te/7IILLrAPP/zQv46kpCRXBqn/lT274oor3DxmgfOeAQAAAEA0KxLpUsas1K5d201CnR11bZw6dWoBbhkAAAAAxFnzDwAAAACIZwRmAAAAABBhBGYAAAAAEGEEZgAAAAAQYQRmAAAAABBhBGYAAAAAEGEEZgAAAAAQYQRmAAAAABBhBGYAAAAAEGEEZlHIZzHEF1NbCwAAgMNkzJgx1qpVKytbtqy7dOzY0aZNm5bp8uPGjbOEhISgS/HixTMst2LFCjvnnHOsXLlyVqpUKWvXrp2tW7cuw3I+n8+6d+/u1vPee+9ZtCsS6Q1A7NPBjsgjRgYAANGkVq1a9vDDD1ujRo1ckDR+/Hjr2bOnLVq0yJo3bx7yMWXLlrWVK1dmep65evVqO+GEE6xv3742bNgwt/zy5ctDBnBPP/10TJ2nEpgBhYTPfKbPHgI0AAAQDc4+++yg6w899JDLos2fPz/TwCwhIcGqV6+e6TrvvfdeO/PMM+3RRx/139agQYMMyy1evNieeOIJ++6776xGjRoWCyhljNoT7NiI7ilkjB4KyGLluAEAAPElNTXVJk6caLt373YljZnZtWuX1a1b12rXru2ya8qGedLS0uzjjz+2o446yrp162ZVq1a19u3bZyhT3LNnj11++eX23HPPZRnkRRsCszwhHPHvCZ/PCAWihN4LAjMAABBmO3bsCLrs378/02WXLl1qpUuXtmLFitkNN9xgU6ZMsWbNmoVctnHjxvbqq6/a+++/b6+//roLxDp16mS///67u3/Lli0ucFN55BlnnGEzZsyw8847z84//3ybM2eOfz0DBgxwj1NgF0soZUS+EQxEhzQXmEV6KwAAQCQl7zhoRYokhWXdCYcOuv+VzQo0ZMgQGzp0aKbBlsoKU1JSbPLkydanTx8XRIUKzjp27BiUTVNw1bRpU3vxxRdtxIgRLlATBVwKvuToo4+2uXPn2gsvvGCdO3e2Dz74wD777DM3ji3WEJhFKc6vkVuUMgIAgMNh/fr1rumGR9mwzBQtWtQaNmzofm7btq0tWLDARo8e7YKt7CQnJ1ubNm1s1apV7nrlypWtSJEiGYI6BW9fffWV+1lBmRqElC9fPmiZCy64wE488USbPXu2RSsCM+QLRZ3RVVZKRA8AAMLNa3+fF8p6ZVX6mH5cmkoh1ezDC/LUGj+wa6P8/PPPblya3H333XbttdcG3d+yZUt76qmnMjQjiTYEZlEo1rrqUT4XPcdNIm8GAACIEoMHD3bziNWpU8d27txpEyZMcBmr6dOnu/t79+5tRxxxhI0aNcpdHz58uHXo0MFl2LZv326PPfaY/fbbb0GB1sCBA+2SSy6xk046yU455RT75JNP7MMPP/RnwtTsI1TDD21DvXr1LJoRmCGugsjCLJa6eQIAgMJPzToUfG3cuNFNBq3JphWUnX766e5+TQqdmPi/XoTbtm2zfv362aZNm6xChQqu9FHjxwJLF9XsQ+PJFMz179/fjWF755133NxmsY7ADCgkEqhjBAAAUeSVV17J8v70472eeuopd8nONddc4y65Gu4RA2iXj3whQRNdYuWDBwAAAMEIzJBvxALREyTzXgAAAMQmAjOgMAVm9MkEAACISQRmUYjyQOTxyGH+AgAAgBhFYBalYmWkED0Ao62UMVaOHAAAAAQiMMsTwpFABAPRQa3yicsAAABiE4EZUIi+LmCMGQAAQGwiMEP+szTsw+jA4EQAAICYRWAWpSgPRJ6OmzTCZAAAgFhEYIZ8YbRd9EgkYwYAABCzCMyQb2T3ogfNPwAAAGITgVkUSiAPhbwcN6QvAQAAYhaBGQAAAABEGIEZAAAAAEQYgRkAAAAARBiBGQAAAABEGIEZAAAAAEQYgRkAAAAARBiBGQAAAABEGIEZAAAAAERYkUhvAAAAAICCkbx9nxVJ8oVldyak7g/LevEPMmYAAAAAEGEEZgAAAAAQYQRmAAAAABBhBGYAAAAAEGEEZgAAAAAQYQRmAAAAABBhBGYAAAAAEGEEZsi3hIQE9mIU8IVnyhIAAAAcBgRmQCFCjAwAABCbCMyiFFkoAAAAIH4QmEUhn8VOTVrsbGl8HDcE9AAAALEpooHZqFGjrF27dlamTBmrWrWqnXvuubZy5Ur//Vu3brVbb73VGjdubCVKlLA6depY//79LSUlJWg9OhlNf5k4cWIEXhEQ4TFmDPcDAACISRENzObMmWM333yzzZ8/32bOnGkHDx60rl272u7du939f/zxh7s8/vjjtmzZMhs3bpx98skn1rdv3wzrGjt2rG3cuNF/UZAHAAAAALGgSCSfXEFWIAVeypwtXLjQTjrpJGvRooW98847/vsbNGhgDz30kF1xxRV26NAhK1Lkf5tfvnx5q169+mHdfihLQzEjAAAAUKjGmHklihUrVsxymbJlywYFZaLMW+XKle24446zV199lYAB8cfnswRqGQEAAGJSRDNmgdLS0uz222+3448/3mXKQvnrr79sxIgRdt111wXdPnz4cOvSpYuVLFnSZsyYYTfddJPt2rXLjUcLZf/+/e7i2bFjh0WbWBoqFEvbCgAAAESjqAnMlPHSOLKvvvoq5P0Knnr06GHNmjWzoUOHBt13//33+39u06aNG6P22GOPZRqYqenIsGHD8rG1lO8h+rjeH0TJAAAAMSkqShlvueUW++ijj+zzzz+3WrVqZbh/586ddsYZZ7jujVOmTLHk5OQs19e+fXv7/fffg7JigQYPHuxKIr3L+vXrC+y1xCNatEfPeD/eCwAAgNhUJNInkmqHr2Br9uzZVq9evZCZsm7dulmxYsXsgw8+sOLFi2e73sWLF1uFChXcY0LR7ZndBwAAAABxFZipfHHChAn2/vvvu2zYpk2b3O3lypVz85YpKFP7/D179tjrr7/urnvjwapUqWJJSUn24Ycf2ubNm61Dhw4uaFPb/ZEjR9qdd94ZyZcWNyjqjB7MYwYAABC7IhqYjRkzxv1/8sknZ5iT7KqrrrLvv//evvnmG3dbw4YNg5ZZs2aNHXnkka6s8bnnnrMBAwa4DJyWe/LJJ61fv34Wq+hAjzweOew4AACAGBXRMWYKpEJdFJR5AVtmyygoE409W7RokRuHpk6MKmO8/vrrLTExKobPxQUaTkRPQE+7fAAAEC2UhGnVqpWb6kqXjh072rRp07J8zKRJk6xJkyauEq5ly5Y2derUoPs1nj7URY3/PIoT0t//8MMPW7QjegEKEYJkAAAQLdTUTwHRwoUL7bvvvnPTW/Xs2dOWL18ecvm5c+faZZddZn379nWJl3PPPddd1Lnds3HjxqCL5i9W4HXBBRdkmE4rcDn1tYh2UdMuH0ABZMyIzAAAQJQ4++yzg64/9NBDLos2f/58a968eYblR48e7arhBg4c6K5r/mL1j3j22WfthRdecLdVr1496DHqVXHKKadY/fr1g25X/4r0y0Y7MmbIF8bDRQ8fY8wAAECUSk1NtYkTJ7r5hlXSGMq8efPstNNOC7pN3dl1eyhqAPjxxx+7DFt6ytRVqlTJzXGsMsdDhw5ZtCNjBhSqGaYjvREAAKCw87qk52QqqqVLl7pAbN++fVa6dGk3TVazZs1CLrtp0yarVq1a0G267nVuT2/8+PEuM3b++ecH3d6/f3875phjrGLFiq48UnMYq5xRDQKjGYEZ8p2lIRaIHjT/AAAgviVs32kJiQfCs+60/e7/2rVrB90+ZMgQGzp0aMjHNG7c2DXnS0lJscmTJ1ufPn1szpw5mQZnuaHxZb169cowz/Edd9zh/1nNR4oWLeqaA44aNSqq5zImMAMKCXUrBQAACLf169e7LouerIIdBUXetFdt27a1BQsWuLFkL774YoZlq1ev7soTA+l6qLFiX375pa1cudLeeuutbLe3ffv2rpRx7dq1LlCMVowxi9LMRExlPmg4ETV4KwAAQLh57e+9S26yUGlpabZ//z+Zt/Q6duxos2bNCrpNzT9CjUl75ZVXXKDXunXrbJ9TGTtNpVW1alWLZmTMorTRQkw1ciBTEzV4KwAAQLTQ2K7u3btbnTp13JzDEyZMsNmzZ9v06dPd/b1797YjjjjClRjKbbfdZp07d7YnnnjCevTo4ZqFqM3+Sy+9ZOnHuGm+My2XnhqFfPPNN65To8af6fqAAQPsiiuusAoVKlg0IzBD/GT2Cjm1yo+pgB4AABRqW7ZsccGXGm+UK1fOjfdSUHb66ae7+9etW+cyWZ5OnTq54O2+++6ze+65xxo1amTvvfeetWjRImi9Ctg0hENznqWn7J3u15g3Zebq1avnArPAcWfRisAM+UYoECUUI/NmAACAKKFyw6woe5beRRdd5C5Zue6669wlFHVj1DxpsYgxZsgXxjRFD7KXAAAAsYvADChE6MwIAAAQmwjMgEKUvaT5BwAAQGwiMEO+EQxEUWDGIDMAAICYRGAWhWJp3FYMbWoccJEZAAAAYhCBWZTi/BqFOaAHAABAMAIzoBCh+QcAAEBsIjBDvhEMRNEE06RaAQAAYhKBGVBIUMkIAAAQuwjMgEKErowAAACxicAMKEQSyJsBAADEJAIzoJBgeBkAAEDsIjADAAAAgAgjMAMAAACACCMwAwrRtAVMMg0AABCbCMyiVEKMzZ8FAAAAIO8IzIBChCAZAAAgNhGYAQAAAECEEZghX2jRHj18vBkAAAAxi8AMKEwY7gcAABCTikR6AwAAAAAUjLSt2ywtoWhYdmea70BY1ot/kDEDAAAAgAgjMAMAAACACCMwAwAAAIAIIzADChM6MwIAAMQkAjPkC00Ao0cCbwYAAEDMIjADAAAAgAgjMAMKER+zTAMAAMQkArMoFUtDhQgGokMCtYwAAAAxi8AMKERImAEAAMQmAjOgkKD3BwAAQOwiMAMAAACACCMwAwAAAIAIIzADChFfTLWNAQAAgIfADAAAAAAijMAMAAAAACKMwAwAAAAAIozADAAAAAAijMAMAAAAACKMwAwAAAAAIozADAAAAAAijMAMAAAAAOI5MBs1apS1a9fOypQpY1WrVrVzzz3XVq5cGbTMvn377Oabb7ZKlSpZ6dKl7YILLrDNmzcHLbNu3Trr0aOHlSxZ0q1n4MCBdujQocP8agAAAADk5lw/vXHjxllCQkLQpXjx4kHL7Nq1y2655RarVauWlShRwpo1a2YvvPCC//61a9dmWId3mTRpUtS+QRENzObMmeOCrvnz59vMmTPt4MGD1rVrV9u9e7d/mQEDBtiHH37odqKW/+OPP+z888/335+amuqCsgMHDtjcuXNt/Pjx7g194IEHIvSqAAAAAOTkXD+UsmXL2saNG/2X3377Lej+O+64wz755BN7/fXXbcWKFXb77be7QO2DDz5w99euXTvo8boMGzbMJXm6d+8etW9MkUg+uXZoIAVUiqYXLlxoJ510kqWkpNgrr7xiEyZMsC5durhlxo4da02bNnVvcIcOHWzGjBn2448/2qeffmrVqlWzo48+2kaMGGGDBg2yoUOHWtGiRSP06gAAAID4ld25fmYSEhKsevXqmd6vZEyfPn3s5JNPdtevu+46e/HFF+3bb7+1c845x5KSkjI8fsqUKXbxxRe74CxaRdUYMwViUrFiRfe/3jRF1qeddpp/mSZNmlidOnVs3rx57rr+b9mypQvKPN26dbMdO3bY8uXLD/trAAAAAJD9uX5mdu3aZXXr1nWZr549e2Y4p+/UqZPLjm3YsMF8Pp99/vnn9vPPP7tsXCiKKRYvXmx9+/aN6rclohmzQGlpaS4Nefzxx1uLFi3cbZs2bXIZr/LlywctqyBM93nLBAZl3v3efaHs37/fXdIfJDt3pflv23UoIegxew6k+n/+++BmS9mbavsOHgxa5sDeAyGf79De/z1XoNQ9ySFv37ztL9u+I8HS9uyzzKTt/d+2ZiVhX1KOlvNv077cxeprN262A3t3W+rB/+2fvEgNvevysT6fHS6H8vnaC8rqtX/YoUP7LC318L32cEhIDf37goB9lMY+KszSfAX8gQgg3w75/jnnUxAQK9saznUrARKoWLFi7pLbc/1QGjdubK+++qq1atXKnaM//vjjLhBTcKYxZfLMM8+4LJmuFylSxBITE+3ll1/ONAunCjxV3Gk9Uc0XJW644QZf3bp1fevXr/ff9sYbb/iKFi2aYdl27dr57rrrLvdzv379fF27dg26f/fu3fqt8U2dOjXkcw0ZMsTdz4V9wDHAMcAxwDHAMcAxwDHAMZDTY2D16tW+aLV3715f9erVw348ly5dOsNtOrfOy7l+Thw4cMDXoEED33333ee/7bHHHvMdddRRvg8++MD3ww8/+J555hm3XTNnzszw+D179vjKlSvne/zxx33RLioyZhqs99FHH9kXX3zhj4RFtaFq6rF9+/agrJm6Mnp1o/pf9aSBvK6NmdWmDh482A0a9Gj9Spequ2O5cuUK/PXFOn0rolTy+vXr3WBMsH84hvgd43MouvA5zf7hGAovZW40lCa7ErxIUufCNWvWuHPncFLWUGPAAmWXLcvsXD8nkpOTrU2bNrZq1Sp3fe/evXbPPfe4MWNqACjKrqlUUdm1wCFQMnnyZNuzZ4/17t3bol1EAzO9sbfeeqvbsbNnz7Z69eoF3d+2bVv3ZsyaNcu1yRe12FQA1bFjR3dd/z/00EO2ZcsWN5hQ1PVFAYRaZ4aSWbpVQRmBR+a0b9g/7J/84Bhi/+QXxxD7h+MnvPgdy5pK5qKZgrP0reWj+Vw/J1JTU23p0qV25plnuuvqP6FL+vdCDT9ULhmqjFENQapUqWLRLqKBmdpnquPi+++/7+Y38MaEKUDSnAT6X4P0lN3SNxT6sNCbq2BMHRlFg/wUgF155ZX26KOPunXcd999bt3ZRe8AAAAAInOuL8pkHXHEEW7OMxk+fLg7z2/YsKGranvsscdcu/xrr73W3a94oHPnzm7eYq1DVW9qy//aa6/Zk08+GfT8yrIpSzd16tSYeIsjGpiNGTPG/e+1uvSoJf5VV13lfn7qqadcRKyMmRp2qOPi888/HxQdKzV64403uoCtVKlSrn2m3lQAAAAA0Xuur0q4wOzXtm3brF+/fi6Iq1ChgqugU3v8wEq4iRMnuqFJvXr1sq1bt7rgTBV0N9xwQ9DzqImISicz69YYbSJeypgdpWOfe+45d8mM3oz8RMLKrA0ZMoQMG/uH4ydM+B1j/3AMhRe/Y+wfjiF+x6JRTs71VeIY6KmnnnKXrKiPhIK77IwcOdJdYkWCOoBEeiMAAAAAIJ5F9whGAAAAAIgDBGYAAAAAEGEEZgAAAAAQYXEbmA0dOtRNjhd4adKkicUztRM9++yzrWbNmm5/vPfee0H3azjiAw88YDVq1HDtSTWB3y+//GLxIrv9o+5C6Y+pM844w+KF2ty2a9fOtcPVnILnnnuum3cw0L59+1zr3EqVKlnp0qVdt1VvQvjCLif7R12r0h9D6TtMFfbuXZok1JtHSZ12p02b5r8/no+fnOyfeD9+0nv44YfdPrj99tv9t8X7MZSTfRTPx1F254YcPwi3uA3MpHnz5rZx40b/5auvvrJ4tnv3bmvdunWmHTA1T9y///1ve+GFF+ybb75xUxNo+gJ9UMWD7PaPKBALPKbefPNNixeaQ0QnPPPnz3eTvGvyR7Wn1X7zDBgwwD788EObNGmSW/6PP/6w888/3+JBTvaPqEVw4DGk37t4oZbGOlFcuHChfffdd9alSxfr2bOnLV++3OL9+MnJ/on34yfQggUL7MUXX3SBbKB4P4Zyso/i/TjK6tyQ4wdh54tTQ4YM8bVu3TrSmxG1dGhMmTLFfz0tLc1XvXp132OPPea/bfv27b5ixYr53nzzTV+87x/p06ePr2fPnhHbpmizZcsWt5/mzJnjP16Sk5N9kyZN8i+zYsUKt8y8efN88b5/pHPnzr7bbrstotsVbSpUqOD7z3/+w/GTzf4Rjp9/7Ny509eoUSPfzJkzg/YJn0HZ76N4P46yOjfk+MHhENcZM5XhqSytfv36boI6TXCH0NasWeMm+lP5okeztrdv397mzZvHbguYi0Nlao0bN3aTnv/9999xu29SUlLc/xUrVnT/61t+ZYkCjyGViNSpUycuj6H0+8fzxhtvWOXKla1FixZu8sw9e/ZYPEpNTXUTiCqjqJI9jp+s94+H48dcZrpHjx5BnzXCMZT9PuI4yvzckOMHhX6C6UhSQDFu3Dh3Aq1U9bBhw+zEE0+0ZcuWuTEgCKagTKpVqxZ0u65798U7lTGqJKZevXq2evVqu+eee6x79+4u6EhKSrJ4kpaW5sYsHH/88S7AEB0nRYsWtfLly1u8H0Oh9o9cfvnlVrduXXdSsGTJEhs0aJAbh/buu+9avFi6dKkLNFQirTFAU6ZMsWbNmtnixYs5frLYP8LxYy5Y/f77712ZXnp8BmW/j+L9OMrq3JDjB4dD3AZmOmH2qL5av4z6IHr77betb9++Ed02xKZLL73U/3PLli3dcdWgQQOXRTv11FMt3r6N1R+yeB+3mdv9c9111wUdQ2q0o2NHgb6OpXigEyIFYcooTp482fr06ePGAiHr/aPgLN6Pn/Xr19ttt93mxnAWL1480psTs/sono+jrM4N1fQMCLe4LmUMpG/xjzrqKFu1alWkNyUqVa9e3f2fvnuVrnv3IZjKIFSSFm/H1C233GIfffSRff75565ZgUfHyYEDB2z79u1xfQxltn9C0UmBxNMxpKxqw4YNrW3btq6TpRrujB49muMnm/0TSrwdPyo127Jlix1zzDFWpEgRd1HQqqZV+lnZ+Xj/DMpuH6lENt6Po8zODfkbhsOBwOz/7dq1y30bpG+GkJHK8/ShNGvWLP9tO3bscN0ZA8c34H9+//13N8YsXo4p9URR0KHSqs8++8wdM4F0IpmcnBx0DKk8RvX78XAMZbd/QlFmROLlGMqs7HP//v1xf/xkt39CibfjR1kdlXrqdXuXY4891o0T8n6O58+gnOyjUGX38XYcZXZuGO9/w3B4xG0p45133unmpFKKWu1yhwwZ4j6QLrvsMotX+gAK/EZMDT/0gazmBGrQoDExDz74oDVq1MidVN5///2uBl3zMcX7/tFFteiaE0cBrD7I77rrLvfNtqYUiAcqz5swYYK9//77bpymN25MTWJUAqL/VSZ8xx13uP2leZhuvfVW9wetQ4cOFu/7R8eM7j/zzDPdHEsa26HWzCeddFLIdtaFkZqdqJRInzc7d+50+0OlwNOnT4/74ye7/cPxY+73KnDMpmhaF/0+ebfH82dQTvZRvB9HWZ0bxvvfMBwmvjh1ySWX+GrUqOErWrSo74gjjnDXV61a5Ytnn3/+uWvfnf6iNvBey/z777/fV61aNdcm/9RTT/WtXLnSFy+y2j979uzxde3a1VelShXXEr5u3bq+fv36+TZt2uSLF6H2jS5jx471L7N3717fTTfd5Fp8lyxZ0nfeeef5Nm7c6IsH2e2fdevW+U466SRfxYoV3e9Xw4YNfQMHDvSlpKT44sU111zjfnf0uazfJX3GzJgxw39/PB8/2e0fjp/Q0rd+j/djKLt9FO/HUXbnhhw/CLcE/XO4gkAAAAAAQEaMMQMAAACACCMwAwAAAIAIIzADAAAAgAgjMAMAAACACCMwAwAAAIAIIzADAAAAgAgjMAMAAACACCMwAwAAAIAIIzADgCjw008/WYcOHax48eJ29NFHR3pzkEMJCQn23nvvZXr/2rVr3TKLFy9mnwIAskRgBqBQOPvss+2MM84Ied+XX37pTo6XLFkS8kR5ypQpLigqV66clSlTxpo3b2633367//5x48a5x+iSlJRkFSpUsPbt29vw4cMtJSUl5HOOGjXKLfvYY4/laPuHDBlipUqVspUrV9qsWbNy/foBAEBsIzADUCj07dvXZs6cab///nuG+8aOHWvHHnustWrVKsN9CoIuueQSu+CCC+zbb7+1hQsX2kMPPWQHDx4MWq5s2bK2ceNGt/65c+faddddZ6+99prLbv3xxx8Z1vvqq6/aXXfd5f7PidWrV9sJJ5xgdevWtUqVKoVcJv02xaMDBw5EehMAAAgLAjMAhcJZZ51lVapUcdmtQLt27bJJkya5wC2UDz/80I4//ngbOHCgNW7c2I466ig799xz7bnnngtaTtmy6tWrW40aNaxp06ZufQrQtH4FYIHmzJlje/fudRm1HTt2uOWyonUrINTy+nno0KH+zN5bb71lnTt3diWOb7zxhv3999922WWX2RFHHGElS5a0li1b2ptvvhm0vpNPPtluvfVWl/VTdq9atWr28ssv2+7du+3qq692WcGGDRvatGnTgh63bNky6969u5UuXdo95sorr7S//vrLf//kyZPd85UoUcIFj6eddppbZyizZ8922//xxx+7gFjbr6ykniPQV199ZSeeeKJbZ+3ata1///5B6zzyyCNtxIgR1rt3bxccKyAOJS0tzR599FH3uooVK2Z16tRxAbZn6dKl1qVLF/+2az167zwLFiyw008/3SpXruwyp9rn33//fdBz/PLLL3bSSSe519KsWTP3RUB6Cu7btGnjltGXAYsWLQq5vQAApEdgBqBQKFKkiDt5V2Dm8/n8tysoS01NdcFMKAq2li9fniFgyImqVatar1697IMPPnDP4XnllVfc8yUnJ7v/dT0rysSpfPJf//qX+/nOO+/033f33XfbbbfdZitWrLBu3brZvn37rG3bti7g0TYrwFAApYAg0Pjx412QodsVpN1444120UUXWadOnVzA0bVrV/e4PXv2uOW3b9/uAhcFFd9995198skntnnzZrv44ov926jXcs0117htUeB1/vnnB+3rUBTwPvHEEy7wUeCsklMv86csocpPla1UmamCUAVqt9xyS9A6Hn/8cWvdurULcu6///6QzzN48GB7+OGH3f0//vijTZgwwQWXokBP+05BqrZDx8Snn34a9Dw7d+60Pn36uOefP3++NWrUyM4880x3uxf46fUWLVrUvvnmG3vhhRds0KBBQdugQE9fEChoU6CtADvwvQQAIEs+ACgkVqxYoSjB9/nnn/tvO/HEE31XXHGF//qaNWvcMosWLXLXd+3a5TvzzDPdbXXr1vVdcsklvldeecW3b98+/2PGjh3rK1euXMjnHDNmjHvs5s2b3fWUlBRfiRIlfIsXL3bX9TylS5f27dy5M8ttb926tW/IkCEZtvPpp5/O9nX36NHD969//ct/vXPnzr4TTjjBf/3QoUO+UqVK+a688kr/bRs3bnTrnzdvnrs+YsQIX9euXYPWu379erfMypUrfQsXLnQ/r1271pcTeg+0/MSJE/23/f33327fvPXWW+563759fdddd13Q47788ktfYmKib+/eve663pNzzz03y+fasWOHr1ixYr6XX3455P0vvfSSr0KFCu699nz88cfueTZt2hTyMampqb4yZcr4PvzwQ3d9+vTpviJFivg2bNjgX2batGnuNU6ZMsVdf/HFF32VKlXyb3vg8eEdbwAAZIaMGYBCo0mTJi4j5I3rWrVqlWv8kVkZo6jhhrJPWva+++5zZXzKXB133HH+bFJWvIyRyvZEZYUNGjRwGR7RGDSNG1M2KC9UDhdImTmV9qmksGLFim57p0+fbuvWrQtaLnA8nZqQqHxPj/F42aQtW7a4/3/44Qf7/PPP3fq8i/anl9nS6zn11FPdOpR5U2nktm3bst3+jh07+n/W9qpcVBk37zmV4Qx8TmW2lJ1as2ZNpvsgPa1v//79bvsyu1/br/fao/JVPY+arYiyg/369XOZMpUyqmxSGTBvv2odKrWsWbNmyNfmLeOVbWa2DAAAmSEwA1CoKAh75513XAmamn4oSNJ4oexouWuvvdb+85//uFI/lcPlJJjSybhO4r2GHSpbVGmkSiu9i9aV0yYg6QUGE6Iuj6NHj3ZldAqk1F1SwUz6phgqowykwDHwNi+QVHAiCkJUZqj1BV68cVUK7jSmSuPSVKr3zDPPuCArMIDKLT3n9ddfH/R8Ctb0nHo/MtsH6WncWH6pjFHPr32rMYH6We8pzUYAAIcLgRmAQkVjohITE90YI3VN1JgoLwjJKTWcUGONzBpbeJRt0vOoWYieUw0mND5L468Cgw1dnzdvnpurLL++/vpr69mzp11xxRUuC1S/fn37+eef873eY445xgWUeu1qoBF48QIj7UdlmoYNG+bGe2m8laYayIrGa3mUYdO2qnmK95wKWtM/ny5ad04py6XgLLNpBvR8CvgC30/tR71nCi6962o8onFlGu+nBiKBjU+0jvXr17uxdqFem7eMxsppHGBmywAAkBkCMwCFisrh1P5ezSB0En3VVVdlubwaNKirooInZX8UcCiYU4MKdekLLFnctGmTW6eyZMqAqWxSZW9qOuFly1QCqQxTixYt/Bddb9euXbZNQHIahChzpayOtkMZJ5Xh5dfNN99sW7dudQ0+1CBD5YsqkVQXR5VPquHFyJEjXeCp8r53333X/vzzT3+QlRl1mlTApEYlei/UkESBrCjrp9ehJhxedu7999/P0PwjOyod1Lr0PioY17YrIPL2txq0aBllxbQdyjSqIYqan3glndqv//3vf90+1WvVYwIzcepAqY6dWoeCPJXI3nvvvUHbcfnll7vgVSWRCjinTp3qGpcAAJATBGYACmU5o7IzKvELHBMUisocf/31V9fRUWOq1C5eAdiMGTP82RRR23u1ylebeo0bevHFF91JugI53a6St9dff911GAxFtytoyO9cZBoHp0yTXpva4qurpBfo5If2k7JGCsLUsVFjydRuv3z58i6zpHLNL774wmWUFKBoO9RtUfsrKwpa1VVSnSS1XzU9gZcN03gsTS2gLJpa5qsj5AMPPJDtexaKujFqbKAer2BRwbk3fk7ZTwWZCjwVIF944YVuPNqzzz7rf7yCOB0z2rcK2JQ9U9dNj/aBsoOaBkHBt8peA9vxe18K6PUpc6rXosDtkUceyfVrAQDEpwR1AIn0RgAAChdlIE855RQX7Ci4AwAAWSNjBgAAAAARRmAGAAAAABFGKSMAAAAARBgZMwAAAACIMAIzAAAAAIgwAjMAAAAAiDACMwAAAACIMAIzAAAAAIgwAjMAAAAAiDACMwAAAACIMAIzAAAAAIgwAjMAAAAAsMj6PyFkw5Gjppo3AAAAAElFTkSuQmCC",
+      "text/plain": [
+       "<Figure size 900x600 with 2 Axes>"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    }
+   ],
+   "source": [
+    "pass_data_volume_mb = 281.3  # MB per pass\n",
+    "\n",
+    "# Look at roughly a full's day of data\n",
+    "duration = (0.75 * u.day).to(u.s)\n",
+    "\n",
+    "fpc_values   = np.arange(5, 51, dtype=int)        # VISDA frames_per_coadd: 1 -> 50\n",
+    "roi_y_values = np.arange(200, 405, 5, dtype=int)  # NIRDA roi_y_size: 200 -> 400 (step 5)\n",
+    "\n",
+    "# NIRDA data depends only on roi_y_size; compute one value per row.\n",
+    "nirda_dc_bytes = np.zeros(len(roi_y_values))\n",
+    "for i, roi_y in enumerate(roi_y_values):\n",
+    "    n = NirdaData(roi_y_size=int(roi_y))\n",
+    "    _, _, dc = n.solve_integrations(duration, overhead=overhead)\n",
+    "    nirda_dc_bytes[i] = dc.to(u.byte).value\n",
+    "\n",
+    "# VISDA data depends only on frames_per_coadd; compute one value per column.\n",
+    "visda_dc_bytes = np.zeros(len(fpc_values))\n",
+    "for j, fpc in enumerate(fpc_values):\n",
+    "    v = VisdaData(frames_per_coadd=int(fpc))\n",
+    "    _, _, dc = v.solve_integrations(duration, overhead=overhead)\n",
+    "    visda_dc_bytes[j] = dc.to(u.byte).value\n",
+    "\n",
+    "# Broadcast: total passes at every (roi_y, fpc) grid point.\n",
+    "passes_grid = (\n",
+    "    (nirda_dc_bytes[:, np.newaxis] + visda_dc_bytes[np.newaxis, :]) / 1e6\n",
+    "    / pass_data_volume_mb\n",
+    ")\n",
+    "\n",
+    "fig, ax = plt.subplots(figsize=(9, 6))\n",
+    "\n",
+    "levels = np.linspace(passes_grid.min(), passes_grid.max(), 20)\n",
+    "cf = ax.contourf(fpc_values, roi_y_values, passes_grid, levels=levels, cmap='viridis')\n",
+    "cs = ax.contour(\n",
+    "    fpc_values, roi_y_values, passes_grid,\n",
+    "    levels=levels[::4], colors='white', linewidths=0.6, alpha=0.6,\n",
+    ")\n",
+    "ax.clabel(cs, fmt='%.2f', fontsize=8, inline=True)\n",
+    "\n",
+    "cbar = fig.colorbar(cf, ax=ax)\n",
+    "cbar.set_label('Data volume (passes)', labelpad=10)\n",
+    "\n",
+    "ax.set_xlabel('VISDA frames per coadd')\n",
+    "ax.set_ylabel('NIRDA ROI Y size (px)')\n",
+    "ax.set_title(\n",
+    "    f'Total compressed data  —  {duration.to(u.min).value:.0f} min window'\n",
+    "    f'  ({pass_data_volume_mb} MB / pass)'\n",
+    ")\n",
+    "\n",
+    "plt.tight_layout()\n",
+    "plt.show()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "d351c771-db3b-425a-b718-1113d2b9f827",
+   "metadata": {},
+   "outputs": [],
+   "source": []
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3 (ipykernel)",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.13.12"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}

--- a/docs/run_scheduler_example.py
+++ b/docs/run_scheduler_example.py
@@ -94,6 +94,7 @@ scheduler = ScheduleProcessor(
                 "ROI_SizeX": 80,
                 "ROI_SizeY": 250,
                 "SC_Resets2": 1,
+                "SC_DropFrames1": 1
             },
             "AcquireVisCamScienceData": {
                 "FramesPerCoadd": 50,
@@ -115,6 +116,7 @@ scheduler = ScheduleProcessor(
                 "RiceX": 5,
                 "RiceY": 28,
                 "SC_Resets2": 1,
+                "SC_DropFrames1": 1
             },
             "AcquireVisCamScienceData": {
                 "StarRoiDimension": 50,
@@ -133,6 +135,7 @@ scheduler = ScheduleProcessor(
                 "ROI_SizeX": 80,
                 "ROI_SizeY": 250,
                 "SC_Resets2": 1,
+                "SC_DropFrames1": 1
             },
             "AcquireVisCamScienceData": {
                 "StarRoiDimension": 50,

--- a/docs/run_scheduler_example.py
+++ b/docs/run_scheduler_example.py
@@ -73,6 +73,26 @@ scheduler = ScheduleProcessor(
     roll_step=1.0,                # roll search step size (deg)
     min_power_frac=0.68,          # min acceptable orbit-average power fraction
     force_gap_fill=False,         # if True, aggressively fill scheduling gaps
+    # ----------------------------------------------------------------------
+    # Optional per-priority payload overrides.
+    #
+    # These force specific NIRDA/VISDA payload parameters to the values from
+    # the default NirdaData / VisdaData classes for every observation of a
+    # given priority, instead of using the values carried by the observation.
+    # Each maps a priority -> list of data-class field names to override; the
+    # corresponding payload XML tags are updated and the integration counts
+    # are recomputed accordingly.
+    #
+    # Example: for all priority-0 observations, replace drop_frames_1 and
+    # drop_frames_3 (NIRDA) and frames_per_coadd (VISDA) with class defaults.
+    #
+    # override_nirda_parameters={
+    #     0: ["drop_frames_1", "drop_frames_3"],
+    #     1: ["reset_frames_1"],
+    # },
+    # override_visda_parameters={
+    #     0: ["frames_per_coadd"],
+    # },
 )
 
 # ---------------------------------------------------------------------------

--- a/docs/run_scheduler_example.py
+++ b/docs/run_scheduler_example.py
@@ -135,6 +135,17 @@ scheduler.print_gap_summary()
 scheduler.print_validation_summary(processed_calendar)
 processed_calendar.get_summary_stats()
 
+# Per-day ".diag" report (week summary + per-day data volumes, priority
+# counts, unique targets, observing/gap minutes and percentages, and a file
+# manifest). Written next to the input calendar as "<calendar>.diag" when
+# output_path is omitted; pass pass_data_volume_mb to report required passes.
+print("\n\nGenerating .diag report...")
+scheduler.generate_diagnostics(
+    processed_calendar,
+    output_path=xml_file_path,
+    pass_data_volume_mb=281.3,
+)
+
 
 # ---------------------------------------------------------------------------
 # Write the scheduled calendar back out as XML

--- a/docs/run_scheduler_example.py
+++ b/docs/run_scheduler_example.py
@@ -76,22 +76,23 @@ scheduler = ScheduleProcessor(
     # ----------------------------------------------------------------------
     # Optional per-priority payload overrides.
     #
-    # These force specific NIRDA/VISDA payload parameters to the values from
-    # the default NirdaData / VisdaData classes for every observation of a
-    # given priority, instead of using the values carried by the observation.
-    # Each maps a priority -> list of data-class field names to override; the
+    # These force specific NIRDA/VISDA payload parameters for every
+    # observation of a given priority, instead of using the values carried by
+    # the observation. Each maps a priority -> {field_name: value}; the
     # corresponding payload XML tags are updated and the integration counts
-    # are recomputed accordingly.
+    # are recomputed accordingly. A value of None means "use the default from
+    # the NirdaData / VisdaData class".
     #
-    # Example: for all priority-0 observations, replace drop_frames_1 and
-    # drop_frames_3 (NIRDA) and frames_per_coadd (VISDA) with class defaults.
+    # Example: for all priority-0 observations set drop_frames_1=2 and take
+    # drop_frames_3 from the class default; for priority 1 set
+    # reset_frames_1=30; and set VISDA frames_per_coadd=5 for priority 0.
     #
     # override_nirda_parameters={
-    #     0: ["drop_frames_1", "drop_frames_3"],
-    #     1: ["reset_frames_1"],
+    #     0: {"drop_frames_1": 2, "drop_frames_3": None},
+    #     1: {"reset_frames_1": 30},
     # },
     # override_visda_parameters={
-    #     0: ["frames_per_coadd"],
+    #     0: {"frames_per_coadd": 5},
     # },
 )
 

--- a/docs/run_scheduler_example.py
+++ b/docs/run_scheduler_example.py
@@ -74,26 +74,75 @@ scheduler = ScheduleProcessor(
     min_power_frac=0.68,          # min acceptable orbit-average power fraction
     force_gap_fill=False,         # if True, aggressively fill scheduling gaps
     # ----------------------------------------------------------------------
-    # Optional per-priority payload overrides.
-    #
-    # These force specific NIRDA/VISDA payload parameters for every
-    # observation of a given priority, instead of using the values carried by
-    # the observation. Each maps a priority -> {field_name: value}; the
-    # corresponding payload XML tags are updated and the integration counts
-    # are recomputed accordingly. A value of None means "use the default from
-    # the NirdaData / VisdaData class".
-    #
-    # Example: for all priority-0 observations set drop_frames_1=2 and take
-    # drop_frames_3 from the class default; for priority 1 set
-    # reset_frames_1=30; and set VISDA frames_per_coadd=5 for priority 0.
-    #
-    # override_nirda_parameters={
-    #     0: {"drop_frames_1": 2, "drop_frames_3": None},
-    #     1: {"reset_frames_1": 30},
-    # },
-    # override_visda_parameters={
-    #     0: {"frames_per_coadd": 5},
-    # },
+    # Per-priority payload overrides, by literal XML tag (CalendarCleaner
+    # config.json format): {priority: {section: {xml_tag: value}}}. These are
+    # forced onto every observation of the given priority (creating any
+    # missing tag) before integration counts are recomputed, so ROI / coadd /
+    # reset changes flow through. Priority keys may be ints or "Priority_N".
+    override_payload_parameters={
+        "Priority_0": {
+            "Observational_Parameters": {
+                "Boresight": {
+                    "PRI_CMD_DIR": 9,
+                },
+            },
+            "AcquireInfCamImages": {
+                "ROI_StartX": 1737,
+                "ROI_StartY": 962,
+                "ROI_SizeX": 80,
+                "ROI_SizeY": 250,
+                "SC_Resets2": 1,
+            },
+            "AcquireVisCamScienceData": {
+                "FramesPerCoadd": 50,
+                "MaxNumStarRois": 1,
+                "StarRoiDimension": 50,
+            },
+        },
+        "Priority_1": {
+            "Observational_Parameters": {
+                "Boresight": {
+                    "PRI_CMD_DIR": 9,
+                },
+            },
+            "AcquireInfCamImages": {
+                "ROI_StartX": 1737,
+                "ROI_StartY": 962,
+                "ROI_SizeX": 80,
+                "ROI_SizeY": 250,
+                "RiceX": 5,
+                "RiceY": 28,
+                "SC_Resets2": 1,
+            },
+            "AcquireVisCamScienceData": {
+                "StarRoiDimension": 50,
+                "FramesPerCoadd": 5,
+            },
+        },
+        "Priority_2": {
+            "Observational_Parameters": {
+                "Boresight": {
+                    "PRI_CMD_DIR": 9,
+                },
+            },
+            "AcquireInfCamImages": {
+                "ROI_StartX": 1737,
+                "ROI_StartY": 962,
+                "ROI_SizeX": 80,
+                "ROI_SizeY": 250,
+                "SC_Resets2": 1,
+            },
+            "AcquireVisCamScienceData": {
+                "StarRoiDimension": 50,
+                "FramesPerCoadd": 5,
+            },
+        },
+    },
+    # Field-name overrides (NirdaData/VisdaData fields; None -> class default)
+    # are also available and recompute integrations; the XML-tag form above
+    # is preferred when mirroring the cleaner config:
+    # override_nirda_parameters={0: {"drop_frames_1": 2}},
+    # override_visda_parameters={0: {"frames_per_coadd": 5}},
 )
 
 # ---------------------------------------------------------------------------

--- a/docs/run_scheduler_example.py
+++ b/docs/run_scheduler_example.py
@@ -73,6 +73,7 @@ scheduler = ScheduleProcessor(
     roll_step=1.0,                # roll search step size (deg)
     min_power_frac=0.68,          # min acceptable orbit-average power fraction
     force_gap_fill=False,         # if True, aggressively fill scheduling gaps
+    convert_single_roi_to_predefined=True,  # single auto-detect ROI -> predefined ROI at target RA/Dec
     # ----------------------------------------------------------------------
     # Per-priority payload overrides, by literal XML tag (CalendarCleaner
     # config.json format): {priority: {section: {xml_tag: value}}}. These are

--- a/docs/run_scheduler_example.py
+++ b/docs/run_scheduler_example.py
@@ -83,6 +83,7 @@ processed_calendar = scheduler.process_calendar(
     original_calendar,
     window_start=window_start,
     window_duration_days=window_duration_days,
+    merge_similar_observations=True
 )
 
 # ---------------------------------------------------------------------------

--- a/docs/run_scheduler_example.py
+++ b/docs/run_scheduler_example.py
@@ -74,6 +74,7 @@ scheduler = ScheduleProcessor(
     min_power_frac=0.68,          # min acceptable orbit-average power fraction
     force_gap_fill=False,         # if True, aggressively fill scheduling gaps
     convert_single_roi_to_predefined=True,  # single auto-detect ROI -> predefined ROI at target RA/Dec
+    fix_bad_data=True,            # replace invalid name symbols (e.g. "+") and report NaN-like values
     # ----------------------------------------------------------------------
     # Per-priority payload overrides, by literal XML tag (CalendarCleaner
     # config.json format): {priority: {section: {xml_tag: value}}}. These are

--- a/docs/run_scheduler_example.py
+++ b/docs/run_scheduler_example.py
@@ -161,28 +161,6 @@ processed_calendar = scheduler.process_calendar(
     merge_similar_observations=True
 )
 
-# ---------------------------------------------------------------------------
-# Validate the result
-# ---------------------------------------------------------------------------
-# process_calendar already runs these checks internally; they are repeated
-# here explicitly so the output can be inspected.
-print("\n\nValidating visibility...")
-issues = scheduler.validate_visibility(processed_calendar)
-print("visibility issues:", issues)
-
-print("\n\nValidating exposures...")
-exposure_issues = scheduler.validate_payload_exposures(processed_calendar, report_issues=True)
-print("exposure issues:", exposure_issues)
-
-# Quick overlap check (analogous to validate_visibility).
-print("\n\nValidating overlaps...")
-overlap_issues = scheduler.validate_no_overlaps_astropy(processed_calendar)
-print(f"Found {len(overlap_issues)} overlaps")
-
-# Comprehensive sequence-timing validation.
-print("\n\nValidating timing...")
-all_timing_issues = scheduler.validate_sequence_timing(processed_calendar)
-
 # Human-readable summaries.
 print("\n\nPrinting diagnostics...")
 scheduler.print_timing_summary(processed_calendar)

--- a/docs/run_scheduler_example.py
+++ b/docs/run_scheduler_example.py
@@ -1,0 +1,153 @@
+"""Example: run the short-term scheduler against a long-term science calendar.
+
+This script takes a long-term science calendar (exported as XML), processes it
+into a short-term schedule for a given observing window, runs the built-in
+validation checks, writes the resulting calendar back out as XML, and produces
+a few diagnostic plots.
+
+Usage
+-----
+Update the three blocks marked ``UPDATE ME`` below (calendar path, observing
+window, and spacecraft TLE), then run::
+
+    python run_scheduler_example.py
+
+The TLE, window, and calendar path are the only inputs that normally change
+between runs; the scheduler configuration is mission-driven and is documented
+inline where it is constructed.
+"""
+
+from pathlib import Path
+
+import matplotlib.pyplot as plt
+from astropy.time import Time
+
+from shortschedule import ScheduleProcessor, XMLWriter, parse_science_calendar
+from shortschedule.visualizer import ScheduleVisualizer
+
+
+# ---------------------------------------------------------------------------
+# Inputs — UPDATE ME between runs
+# ---------------------------------------------------------------------------
+xml_file_path = Path("path", "to", "Pandora_science_calendar.xml")
+
+# Base name (without extension) used to label the output plots, e.g.
+# "Pandora_science_calendar".
+calendar_name = xml_file_path.stem
+
+# Observing window: the short-term schedule is built starting at ``window_start``
+# and spanning ``window_duration_days``.
+window_start = Time("2026-06-22T00:00:00Z")
+window_duration_days = 7
+
+# Spacecraft two-line element set (TLE) describing the orbit used for
+# visibility, power, and gap calculations. Refresh this for each new run.
+new_tle1 = "1 67395U 80229J   26166.70761574  .00000000  00000-0  37770-3 0    09"
+new_tle2 = "2 67395  97.8045 165.3849 0006889 124.8823 324.4856 14.88069544    01"
+
+# ---------------------------------------------------------------------------
+# Load the long-term calendar
+# ---------------------------------------------------------------------------
+print("\n\nParsing long-term calendar...")
+original_calendar = parse_science_calendar(str(xml_file_path), verbose=True)
+
+# ---------------------------------------------------------------------------
+# Configure the scheduler
+# ---------------------------------------------------------------------------
+# These constraints are mission-driven and rarely change run-to-run. Gap
+# tolerances are in minutes; the ``*_min`` keel-angle constraints are in
+# degrees. See ScheduleProcessor for the full parameter documentation.
+print("\n\nBuilding scheduler...")
+scheduler = ScheduleProcessor(
+    new_tle1,
+    new_tle2,
+    earthlimb_gap_tolerance=6,    # max allowed Earth-limb gap (minutes)
+    st_gap_tolerance=12,          # max allowed star-tracker gap (minutes); raised per Tom 2026-06-01
+    earthlimb_day_min=44,         # min Earth-limb angle, daytime (deg)
+    earthlimb_night_min=13,       # min Earth-limb angle, nighttime (deg)
+    sun_min=91,                   # min payload Sun keel angle (deg)
+    moon_min=20,                  # min payload Moon keel angle (deg)
+    st_sun_min=50,                # min star-tracker Sun angle (deg)
+    st_moon_min=20,               # min star-tracker Moon angle (deg)
+    st_earthlimb_min=30,          # min star-tracker Earth-limb angle (deg)
+    roll_step=1.0,                # roll search step size (deg)
+    min_power_frac=0.68,          # min acceptable orbit-average power fraction
+    force_gap_fill=False,         # if True, aggressively fill scheduling gaps
+)
+
+# ---------------------------------------------------------------------------
+# Process the calendar into a short-term schedule
+# ---------------------------------------------------------------------------
+print("\n\nProcessing long-term into short-term calendar...")
+processed_calendar = scheduler.process_calendar(
+    original_calendar,
+    window_start=window_start,
+    window_duration_days=window_duration_days,
+)
+
+# ---------------------------------------------------------------------------
+# Validate the result
+# ---------------------------------------------------------------------------
+# process_calendar already runs these checks internally; they are repeated
+# here explicitly so the output can be inspected.
+print("\n\nValidating visibility...")
+issues = scheduler.validate_visibility(processed_calendar)
+print("visibility issues:", issues)
+
+print("\n\nValidating exposures...")
+exposure_issues = scheduler.validate_payload_exposures(processed_calendar, report_issues=True)
+print("exposure issues:", exposure_issues)
+
+# Quick overlap check (analogous to validate_visibility).
+print("\n\nValidating overlaps...")
+overlap_issues = scheduler.validate_no_overlaps_astropy(processed_calendar)
+print(f"Found {len(overlap_issues)} overlaps")
+
+# Comprehensive sequence-timing validation.
+print("\n\nValidating timing...")
+all_timing_issues = scheduler.validate_sequence_timing(processed_calendar)
+
+# Human-readable summaries.
+print("\n\nPrinting diagnostics...")
+scheduler.print_timing_summary(processed_calendar)
+scheduler.print_gap_summary()
+scheduler.print_validation_summary(processed_calendar)
+processed_calendar.get_summary_stats()
+
+
+# ---------------------------------------------------------------------------
+# Write the scheduled calendar back out as XML
+# ---------------------------------------------------------------------------
+print("\n\nWriting calendar...")
+XMLWriter().write_calendar(processed_calendar, mission_phase="COM")
+
+
+# ---------------------------------------------------------------------------
+# Diagnostic plots
+# ---------------------------------------------------------------------------
+print("\n\nCreating visualizations...")
+visualizer = ScheduleVisualizer(scheduler)
+
+# Gantt timeline coloured by observation priority; saved using the calendar name.
+priority_fig = visualizer.plot_gantt_timeline_by_priority(
+    processed_calendar,
+    figsize=(12, 16),
+    show_sequence_labels=False,
+    title="Schedule by Priority",
+)
+priority_fig.savefig(f"{calendar_name}_priority.png", dpi=300)
+
+# Gantt timeline overlaid with visibility windows; saved using the calendar name.
+vis_fig = visualizer.plot_gantt_with_visibility(
+    processed_calendar,
+    figsize=(14, 18),
+    show_sequence_labels=False,
+    title="Schedule — Visibility Check",
+)
+vis_fig.savefig(f"{calendar_name}_visibility.png", dpi=300)
+
+# Simple timeline view including visit boundaries.
+fig, ax = visualizer.plot_timeline(processed_calendar, show_visits=True)
+
+# Display all open figures.
+plt.show()

--- a/example_star_roi_validation.py
+++ b/example_star_roi_validation.py
@@ -11,6 +11,8 @@ Rules applied based on StarRoiDetMethod:
 - Method 2: numPredefinedStarRois = 0, MaxNumStarRois = max number of star boxes
 """
 
+from pathlib import Path
+
 from shortschedule.parser import parse_science_calendar
 from shortschedule.scheduler import ScheduleProcessor
 from shortschedule.writer import XMLWriter
@@ -18,7 +20,10 @@ from shortschedule.writer import XMLWriter
 
 def main():
     # Parse a science calendar
-    calendar_path = "./src/shortschedule/data/Pandora_science_calendar_20251018_tsb-futz.xml"
+    calendar_path = (
+        Path("src") / "shortschedule" / "data"
+        / "Pandora_science_calendar_20251018_tsb-futz.xml"
+    )
     print(f"Parsing calendar: {calendar_path}")
     cal = parse_science_calendar(calendar_path)
     print(

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -16,6 +16,7 @@ appdirs = "^1.4.4"
 astropy = "^7.1.1"
 pandoravisibility = {git = "https://github.com/PandoraMission/pandora-visibility.git", branch = "main"}
 requests = "^2.32.5"
+tqdm = "^4.66.0"
 
 [tool.poetry.group.dev.dependencies]
 pytest = "^8.4.2"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -38,6 +38,7 @@ requires = ["poetry-core>=2.0.0,<3.0.0"]
 build-backend = "poetry.core.masonry.api"
 
 [tool.pytest.ini_options]
+pythonpath = ["src"]
 markers = [
     "slow: marks tests as slow (deselect with '-m \"not slow\"')",
 ]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -36,6 +36,11 @@ notebook = "^7.5.4"
 requires = ["poetry-core>=2.0.0,<3.0.0"]
 build-backend = "poetry.core.masonry.api"
 
+[tool.pytest.ini_options]
+markers = [
+    "slow: marks tests as slow (deselect with '-m \"not slow\"')",
+]
+
 [tool.black]
 line-length = 79
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "shortschedule"
-version = "1.1.3"
+version = "1.2.0"
 description = ""
 authors = ["Tom Barclay <barclay.astro@gmail.com>"]
 readme = "README.md"

--- a/src/shortschedule/__init__.py
+++ b/src/shortschedule/__init__.py
@@ -13,6 +13,7 @@ from .parser import parse_science_calendar
 from .roll import apply_rolls_to_calendar, apply_rolls_to_visit, calculate_roll
 from .scheduler import ScheduleProcessor
 from .writer import XMLWriter
+from .nirda import NirdaData
 
 # Package directory
 PACKAGEDIR = os.path.abspath(os.path.dirname(__file__))
@@ -30,6 +31,7 @@ __all__ = [
     "apply_rolls_to_calendar",
     "get_version",
     "setup_logging",
+    "NirdaData"
 ]
 
 

--- a/src/shortschedule/constriants.py
+++ b/src/shortschedule/constriants.py
@@ -1,0 +1,4 @@
+"""Hardcoded constraints"""
+
+MAX_FILE_SIZE_UNCOMPRESSED_MB = 830.0
+MAX_FILE_SIZE_COMPRESSED_MB = 255.0

--- a/src/shortschedule/constriants.py
+++ b/src/shortschedule/constriants.py
@@ -1,4 +1,0 @@
-"""Hardcoded constraints"""
-
-MAX_FILE_SIZE_UNCOMPRESSED_MB = 830.0
-MAX_FILE_SIZE_COMPRESSED_MB = 255.0

--- a/src/shortschedule/data/visda.py
+++ b/src/shortschedule/data/visda.py
@@ -1,0 +1,211 @@
+"""VISDA detector data helper functions.
+
+This module implements ``VisdaData``, a dataclass that calculates VISDA
+frame times and data volumes for a single observation. The calculations
+require:
+
+- per-observation details such as the ROI dimension, number of ROIs, and
+  frames per coadd.
+- detector configuration such as exposure time, read time per frame, and
+  bytes per pixel.
+
+Notes
+-----
+VISDA reads out one or more square ROIs and coadds a fixed number of
+frames on-board. Each frame takes ``exposure_time_s + read_time_per_frame_s``
+to acquire, and ``frames_per_coadd`` consecutive frames are combined into a
+single coadd before downlink.
+"""
+
+import math
+from dataclasses import dataclass, field
+
+from astropy import units as u
+from astropy.units import Quantity
+
+
+@dataclass
+class VisdaData:
+    """VISDA timing and data-volume parameters for a single observation.
+
+    All timing and data results are computed automatically in
+    ``__post_init__`` via ``_update_derived``.  Derived attributes
+    (``init=False``) should be treated as read-only after construction.
+
+    Parameters
+    ----------
+    frames_per_coadd : int
+        Number of consecutive frames combined into a single coadd on-board.
+    roi_dimension : int
+        Side length of each square ROI in pixels.
+    num_rois : int
+        Number of ROIs read out per frame.
+    exposure_time_s : Quantity[second]
+        Per-frame exposure time.
+    is_vissci : bool
+        Whether the observation is in science mode (``True``) or imaging
+        mode (``False``). Selects which ``*_bytes_per_pixel`` applies.
+    compression_ratio : float
+        Effective on-board compression factor applied to raw data.
+        This is an empirical parameter.
+    vissci_bytes_per_pixel : Quantity[byte]
+        Raw storage cost per pixel in science mode.
+    visimg_bytes_per_pixel : Quantity[byte]
+        Raw storage cost per pixel in imaging mode.
+    read_time_per_frame_s : Quantity[second]
+        Detector read time per frame. Effectively negligible compared to
+        the exposure time.
+    additional_overhead_time : Quantity[second]
+        Extra fixed overhead beyond ``pre_overhead_time`` and
+        ``post_overhead_time`` subtracted before scheduling frames.
+    dropped_frames : int
+        Number of frames dropped as a buffer.
+
+    Attributes
+    ----------
+    pixels_per_frame : int
+        Total pixels read out per frame across all ROIs.
+    frame_bytes : Quantity[byte]
+        Raw data volume of a single frame before compression.
+    coadd_bytes : Quantity[byte]
+        Raw data volume of one coadd (``frame_bytes * frames_per_coadd``).
+    single_frame_time : Quantity[second]
+        Wall-clock duration of one frame (exposure plus read time).
+    dropped_integration_time : Quantity[second]
+        Wall-clock duration of the dropped-frame buffer.
+    """
+
+    # VISDA observation configurations
+    frames_per_coadd: int = 5
+    roi_dimension: int = 50
+    num_rois: int = 9
+    exposure_time_s: Quantity = 0.2 * u.s
+    is_vissci: bool = True
+
+    # VISDA detector configuration
+    compression_ratio: float = 0.25
+    vissci_bytes_per_pixel: Quantity = 4 * u.byte
+    visimg_bytes_per_pixel: Quantity = 2 * u.byte
+    read_time_per_frame_s: Quantity = 1.0e-6 * u.s  # This is not correct but this parameter is effectively 0 compared to the exposure time.
+    additional_overhead_time: Quantity = 0 * u.s
+    dropped_frames: int = 0
+
+    # Derived attributes: computed in _update_derived, not constructor arguments
+    pixels_per_frame: int = field(init=False)
+    frame_bytes: Quantity = field(init=False)
+    coadd_bytes: Quantity = field(init=False)
+    single_frame_time: Quantity = field(init=False)
+    dropped_integration_time: Quantity = field(init=False)
+
+    def __post_init__(self):
+        self._update_derived()
+
+    def _update_derived(self):
+        """Recompute all derived timing and data-volume attributes."""
+        self.pixels_per_frame = max(0, self.roi_dimension**2 * self.num_rois)
+
+        if self.is_vissci:
+            bytes_per_pixel = self.vissci_bytes_per_pixel
+        else:
+            bytes_per_pixel = self.visimg_bytes_per_pixel
+
+        self.frame_bytes = max(
+            0, (self.pixels_per_frame * bytes_per_pixel).to(u.byte).value
+        ) * u.byte
+        self.coadd_bytes = self.frame_bytes * self.frames_per_coadd
+
+        self.single_frame_time = max(
+            0,
+            (self.exposure_time_s.to(u.s) + self.read_time_per_frame_s.to(u.s)).value,
+        ) * u.s
+        self.dropped_integration_time = self.dropped_frames * self.single_frame_time
+
+    def solve_integrations(
+        self,
+        duration: Quantity,
+        pre_overhead_time: Quantity = 258.0 * u.s,
+        post_overhead_time: Quantity = 102.0 * u.s,
+    ):
+        """Compute the number of frames that fit within a duration.
+
+        Parameters
+        ----------
+        duration : Quantity[second]
+            Total available observation time.
+        pre_overhead_time : Quantity[second], optional
+            Fixed overhead before science frames begin.
+        post_overhead_time : Quantity[second], optional
+            Fixed overhead after science frames end.
+
+        Returns
+        -------
+        frames : int
+            Number of frames that fit in the available time, floored to a
+            whole number of coadds.
+        data : Quantity[byte]
+            Total raw data volume for those frames.
+        data_compressed : Quantity[byte]
+            Total compressed data volume.
+        """
+        buffered_time = (
+            duration.to(u.s)
+            - pre_overhead_time.to(u.s)
+            - post_overhead_time.to(u.s)
+            - self.additional_overhead_time.to(u.s)
+        )
+        buffered_time = max(0, buffered_time.value) * u.s
+
+        # Find total number of frames that can fit into our observation time.
+        if self.single_frame_time.to(u.s).value <= 0:
+            frames = 0
+        else:
+            frames = max(
+                0,
+                math.floor(
+                    (buffered_time / self.single_frame_time).to(u.dimensionless_unscaled).value
+                ),
+            )
+
+        # Number of frames needs to be a multiple of coadds.
+        if self.frames_per_coadd > 0:
+            frames = max(0, frames - (frames % self.frames_per_coadd))
+
+        data = frames * self.frame_bytes
+        return (frames, data, data * self.compression_ratio)
+
+    def solve_duration(
+        self,
+        integrations: int,
+        pre_overhead_time: Quantity = 258.0 * u.s,
+        post_overhead_time: Quantity = 102.0 * u.s,
+    ):
+        """Compute the total duration required to acquire a given number of frames.
+
+        Parameters
+        ----------
+        integrations : int
+            Desired number of frames.
+        pre_overhead_time : Quantity[second], optional
+            Fixed overhead before science frames begin.
+        post_overhead_time : Quantity[second], optional
+            Fixed overhead after science frames end.
+
+        Returns
+        -------
+        duration : Quantity[second]
+            Total wall-clock time needed, including all overheads.
+        data : Quantity[byte]
+            Total raw data volume for those frames.
+        data_compressed : Quantity[byte]
+            Total compressed data volume.
+        """
+        integrations = max(0, integrations)
+        overhead_time = pre_overhead_time + post_overhead_time + self.additional_overhead_time
+        data = integrations * self.frame_bytes
+
+        if integrations == 0:
+            duration = 0.0 * u.s
+        else:
+            duration = integrations * self.single_frame_time + overhead_time
+
+        return (duration, data, data * self.compression_ratio)

--- a/src/shortschedule/nirda.py
+++ b/src/shortschedule/nirda.py
@@ -307,8 +307,6 @@ class NirdaData:
                 math.ceil((vitl_settling_time / self.reset_frame_time).decompose().value),
             )
 
-        # TODO: Open Question! Do we add the global reset time to this?
-
         self._update_derived()
 
     def solve_integrations(

--- a/src/shortschedule/nirda.py
+++ b/src/shortschedule/nirda.py
@@ -29,7 +29,7 @@ from dataclasses import dataclass, field
 from astropy import units as u
 from astropy.units import Quantity
 
-from typing import TYPE_CHECKING
+from typing import Any, TYPE_CHECKING
 if TYPE_CHECKING:
     from .overhead import OverheadTiming
 
@@ -200,8 +200,20 @@ class NirdaData:
     integration_data: Quantity = field(init=False)
     reset_frame_time: Quantity = field(init=False)
 
+    # Optional logger. When provided (e.g. by ScheduleProcessor) warnings are
+    # sent to it so they share the run log; otherwise ``warnings.warn`` is
+    # used. Excluded from repr/equality so it never affects data comparisons.
+    logger: Any = field(default=None, repr=False, compare=False)
+
     def __post_init__(self):
         self._update_derived()
+
+    def _warn(self, message: str) -> None:
+        """Emit a warning via the attached logger, or ``warnings.warn``."""
+        if self.logger is not None:
+            self.logger.warning(message)
+        else:
+            warn(message)
 
     def _update_derived(self):
         """Recompute all derived timing and data-volume attributes."""
@@ -255,7 +267,7 @@ class NirdaData:
             + self.reset_frame_time.to(u.s).value * self.reset_frames_1,
         ) * u.s
         if self.first_integration_time == 0 * u.s:
-            warn("NIRDA: First integration time found to be 0.")
+            self._warn("NIRDA: First integration time found to be 0.")
 
         self.other_integration_time = max(
             0,
@@ -263,7 +275,7 @@ class NirdaData:
             + self.reset_frame_time.to(u.s).value * self.reset_frames_2,
         ) * u.s
         if self.other_integration_time == 0 * u.s:
-            warn("NIRDA: Other integration time found to be 0.")
+            self._warn("NIRDA: Other integration time found to be 0.")
 
         # If we drop any integrations then the duration of those drops will always be equal to the "other"
         # integration time.
@@ -289,7 +301,7 @@ class NirdaData:
         ) * u.byte
         
         if self.integration_data == 0 * u.byte:
-            warn("NIRDA: Data size per integration was found to be 0.")
+            self._warn("NIRDA: Data size per integration was found to be 0.")
 
     def update_for_vitl(self, vitl_settling_time: Quantity):
         """Adjust ``reset_frames_1`` to cover a VITL settling time and recompute.
@@ -311,7 +323,7 @@ class NirdaData:
         MIN_RESET1 = 2
         if self.reset_frame_time.to(u.s).value == 0.0:
             # Have at least 2 reset1
-            warn(f"NIRDA Reset frame time is approx. 0. Using default ``reset1={MIN_RESET1}.``")
+            self._warn(f"NIRDA Reset frame time is approx. 0. Using default ``reset1={MIN_RESET1}.``")
             self.reset_frames_1 = MIN_RESET1
         else:
             self.reset_frames_1 = max(

--- a/src/shortschedule/nirda.py
+++ b/src/shortschedule/nirda.py
@@ -23,6 +23,7 @@ shorter ``reset_frames_2``).
 from __future__ import annotations
 
 import math
+from warnings import warn
 from dataclasses import dataclass, field
 
 from astropy import units as u
@@ -181,7 +182,7 @@ class NirdaData:
     roi_y_buffer_pixels: int = 2
     read_time_per_pixel: Quantity = 1.0e-5 * u.s
     bytes_per_pixel: Quantity = 2 * u.byte
-    dropped_integrations: int = 0
+    dropped_integrations: int = 1  # TODO: As a buffer we are dropping one NIRDA integration.
     compression_ratio: float = 0.8
     global_reset_method: str = 'off'
     global_reset_lbl_rows: int = 256
@@ -253,19 +254,24 @@ class NirdaData:
             common_integration_time
             + self.reset_frame_time.to(u.s).value * self.reset_frames_1,
         ) * u.s
+        if self.first_integration_time == 0 * u.s:
+            warn("NIRDA: First integration time found to be 0.")
 
         self.other_integration_time = max(
             0,
             common_integration_time
             + self.reset_frame_time.to(u.s).value * self.reset_frames_2,
         ) * u.s
+        if self.other_integration_time == 0 * u.s:
+            warn("NIRDA: Other integration time found to be 0.")
 
         # If we drop any integrations then the duration of those drops will always be equal to the "other"
         # integration time.
         self.dropped_integration_time = self.other_integration_time
 
         bytes_per_frame = max(
-            0, (self.bytes_per_pixel * self.pixels_per_frame).to(u.byte).value
+            0,
+            (self.bytes_per_pixel * self.pixels_per_frame).to(u.byte).value
         ) * u.byte
 
         if self.average_groups:
@@ -278,8 +284,12 @@ class NirdaData:
             self.integration_data = bytes_per_frame * self.groups * self.read_frames
 
         self.integration_data = max(
-            0, self.integration_data.to(u.byte).value
+            0,
+            self.integration_data.to(u.byte).value
         ) * u.byte
+        
+        if self.integration_data == 0 * u.byte:
+            warn("NIRDA: Data size per integration was found to be 0.")
 
     def update_for_vitl(self, vitl_settling_time: Quantity):
         """Adjust ``reset_frames_1`` to cover a VITL settling time and recompute.
@@ -298,12 +308,14 @@ class NirdaData:
         
         # TODO: Open Question! Do we add the global reset time to this?
 
+        MIN_RESET1 = 2
         if self.reset_frame_time.to(u.s).value == 0.0:
             # Have at least 2 reset1
-            self.reset_frames_1 = 2
+            warn(f"NIRDA Reset frame time is approx. 0. Using default ``reset1={MIN_RESET1}.``")
+            self.reset_frames_1 = MIN_RESET1
         else:
             self.reset_frames_1 = max(
-                1,
+                MIN_RESET1,
                 math.ceil((vitl_settling_time / self.reset_frame_time).decompose().value),
             )
 

--- a/src/shortschedule/nirda.py
+++ b/src/shortschedule/nirda.py
@@ -32,6 +32,26 @@ from typing import TYPE_CHECKING
 if TYPE_CHECKING:
     from .overhead import OverheadTiming
 
+
+# Converters between payload XML text and NirdaData config values. Payload
+# values are sometimes written as floats (e.g. "5.0"), so ints are parsed
+# via float first.
+def _xml_to_int(value: str) -> int:
+    return int(float(value))
+
+
+def _int_to_xml(value) -> str:
+    return str(int(value))
+
+
+def _xml_to_bool(value: str) -> bool:
+    return bool(int(float(value)))
+
+
+def _bool_to_xml(value) -> str:
+    return str(int(bool(value)))
+
+
 @dataclass
 class NirdaData:
     """NIRDA timing and data-volume parameters for a single observation.
@@ -114,6 +134,33 @@ class NirdaData:
     integration_data : Quantity[byte]
         Data volume per science integration after on-board averaging.
     """
+
+    # Payload (PAN-SCICAL XML) integration. These are plain class attributes
+    # (no annotations) so the dataclass does not treat them as fields.
+    #
+    # PAYLOAD_SECTION : the payload element these config fields live under.
+    # CONFIG_SPEC     : maps a config field -> (xml_tag, from_xml, to_xml),
+    #                   describing how to read/write each field from/to the
+    #                   payload XML.
+    # REQUIRED_CONFIG_FIELDS : fields needed to compute SC_Integrations
+    #                   (average_groups only affects data volume, so it is
+    #                   optional).
+    PAYLOAD_SECTION = "AcquireInfCamImages"
+    CONFIG_SPEC = {
+        "roi_x_size": ("ROI_SizeX", _xml_to_int, _int_to_xml),
+        "roi_y_size": ("ROI_SizeY", _xml_to_int, _int_to_xml),
+        "reset_frames_1": ("SC_Resets1", _xml_to_int, _int_to_xml),
+        "reset_frames_2": ("SC_Resets2", _xml_to_int, _int_to_xml),
+        "drop_frames_1": ("SC_DropFrames1", _xml_to_int, _int_to_xml),
+        "drop_frames_2": ("SC_DropFrames2", _xml_to_int, _int_to_xml),
+        "drop_frames_3": ("SC_DropFrames3", _xml_to_int, _int_to_xml),
+        "read_frames": ("SC_ReadFrames", _xml_to_int, _int_to_xml),
+        "groups": ("SC_Groups", _xml_to_int, _int_to_xml),
+        "average_groups": ("AverageGroups", _xml_to_bool, _bool_to_xml),
+    }
+    REQUIRED_CONFIG_FIELDS = frozenset(
+        f for f in CONFIG_SPEC if f != "average_groups"
+    )
 
     # NIRDA observation configurations
     reset_frames_1: int = 50
@@ -371,3 +418,16 @@ class NirdaData:
             )
 
         return (duration, data, data * self.compression_ratio)
+
+    def get_config(self) -> dict:
+        """Return the current payload-config field values.
+
+        Returns
+        -------
+        dict
+            Maps each :data:`CONFIG_SPEC` field name to this instance's
+            current value (e.g. ``{'roi_x_size': 80, 'reset_frames_1': 50,
+            ...}``). Useful for reading the default detector configuration
+            when applying per-field overrides.
+        """
+        return {field: getattr(self, field) for field in self.CONFIG_SPEC}

--- a/src/shortschedule/nirda.py
+++ b/src/shortschedule/nirda.py
@@ -1,0 +1,320 @@
+"""NIRDA detector data helper functions.
+
+This module implements ``NirdaData``, a dataclass that calculates NIRDA
+frame times and data volumes for a single observation. The calculations
+require:
+
+- per-observation details such as read frames, drop frames, and resets.
+- detector configuration such as ROI size, read time per pixel, and bytes
+  per pixel.
+
+Notes
+-----
+NIRDA reads out a 2-D ROI up a ramp. Each integration consists of::
+
+    reset frames → drop_frames_1 → groups x (read_frames + drop_frames_2)
+                                 → drop_frames_3
+
+Two integration lengths are tracked: the *first* integration (which uses
+``reset_frames_1``) and all *subsequent* integrations (which use the
+shorter ``reset_frames_2``).
+"""
+
+import math
+from dataclasses import dataclass, field
+
+from astropy import units as u
+from astropy.units import Quantity
+
+
+@dataclass
+class NirdaData:
+    """NIRDA timing and data-volume parameters for a single observation.
+
+    All timing and data results are computed automatically in
+    ``__post_init__`` via ``_update_derived``.  Derived attributes
+    (``init=False``) should be treated as read-only after construction.
+
+    Parameters
+    ----------
+    reset_frames_1 : int
+        Reset frames at the start of the *first* integration.
+    reset_frames_2 : int
+        Reset frames at the start of all *subsequent* integrations.
+    drop_frames_1 : int
+        Drop frames between the initial reset and the first group.
+    drop_frames_2 : int
+        Drop frames between consecutive groups.
+    drop_frames_3 : int
+        Drop frames after the last group.
+    read_frames : int
+        Non-destructive read frames per group.
+    groups : int
+        Number of groups per integration.
+    average_groups : bool
+        Whether groups are averaged on-board before downlink. Affects
+        ``integration_data`` but not timing.
+    roi_x_size : int
+        Width of the science ROI in pixels, excluding buffer columns.
+    roi_y_size : int
+        Height of the science ROI in pixels, excluding buffer rows.
+    roi_x_start : int
+        Starting column of the ROI on the full detector (pixels).
+    roi_y_start : int
+        Starting row of the ROI on the full detector (pixels).
+    roi_x_buffer_pixels : int
+        Extra columns read per row for detector reference pixels.
+    roi_y_buffer_pixels : int
+        Extra rows read per frame for detector reference pixels.
+    read_time_per_pixel : Quantity[second]
+        Detector clock period per pixel during readout.
+    bytes_per_pixel : Quantity[byte]
+        Raw storage cost per pixel before compression.
+    dropped_integrations : int
+        Number of integrations that are dropped as a buffer.
+    compression_ratio : float
+        Effective on-board compression factor applied to raw data.
+        This is an empirical parameter.
+    reset_frame_time : Quantity[second]
+        Explicit reset-frame duration. A negative value means the reset
+        frame takes the same time as a science frame (``single_frame_time``).
+    additional_overhead_time : Quantity[second]
+        Extra fixed overhead beyond ``pre_overhead_time`` and
+        ``post_overhead_time`` subtracted before scheduling integrations.
+
+    Attributes
+    ----------
+    pixels_per_frame : int
+        Total pixels clocked out per frame, including buffer pixels.
+    single_frame_time : Quantity[second]
+        Wall-clock duration of one detector frame.
+    first_integration_saved_frames : int
+        Frames written to memory for the first integration.
+    other_integration_saved_frames : int
+        Frames written to memory for each subsequent integration.
+    first_integration_time : Quantity[second]
+        Wall-clock duration of the first integration.
+    other_integration_time : Quantity[second]
+        Wall-clock duration of each subsequent integration.
+    dropped_integration_time : Quantity[second]
+        Wall-clock duration of a dropped (non-science) integration.
+    integration_data : Quantity[byte]
+        Data volume per science integration after on-board averaging.
+    """
+
+    # NIRDA observation configurations
+    reset_frames_1: int = 50
+    reset_frames_2: int = 1
+    drop_frames_1: int = 1
+    drop_frames_2: int = 16
+    drop_frames_3: int = 0
+    read_frames: int = 4
+    groups: int = 6
+    average_groups: bool = True
+    roi_x_size: int = 80
+    roi_y_size: int = 250
+    roi_x_start: int = 1737
+    roi_y_start: int = 962
+
+    # NIRDA detector configurations
+    roi_x_buffer_pixels: int = 12
+    roi_y_buffer_pixels: int = 2
+    read_time_per_pixel: Quantity = 1.0e-5 * u.s
+    bytes_per_pixel: Quantity = 2 * u.byte
+    dropped_integrations: int = 0
+    compression_ratio: float = 0.8
+    reset_frame_time: Quantity = -1.0 * u.s
+    additional_overhead_time: Quantity = 2 * u.s
+
+    # Derived attributes: computed in _update_derived, not constructor arguments
+    pixels_per_frame: int = field(init=False)
+    single_frame_time: Quantity = field(init=False)
+    first_integration_saved_frames: int = field(init=False)
+    other_integration_saved_frames: int = field(init=False)
+    first_integration_time: Quantity = field(init=False)
+    other_integration_time: Quantity = field(init=False)
+    dropped_integration_time: Quantity = field(init=False)
+    integration_data: Quantity = field(init=False)
+
+    def __post_init__(self):
+        self._update_derived()
+
+    def _update_derived(self):
+        """Recompute all derived timing and data-volume attributes."""
+        common_frames = max(
+            0,
+            self.drop_frames_1
+            + (self.groups - 1) * self.drop_frames_2
+            + self.drop_frames_3
+            + self.groups * self.read_frames
+        )
+
+        self.pixels_per_frame = max(
+            0,
+            (self.roi_x_size + self.roi_x_buffer_pixels)
+            * (self.roi_y_size + self.roi_y_buffer_pixels),
+        )
+
+        self.single_frame_time = max(
+            0, (self.pixels_per_frame * self.read_time_per_pixel).to(u.s).value
+        ) * u.s
+
+        # Replace the negative sentinel with the actual frame time so that
+        # update_for_vitl can use reset_frame_time directly.
+        if self.reset_frame_time < 0 * u.s:
+            self.reset_frame_time = self.single_frame_time
+
+        self.first_integration_time = max(
+            0,
+            self.single_frame_time.to(u.s).value * common_frames
+            + self.reset_frame_time.to(u.s).value * self.reset_frames_1,
+        ) * u.s
+
+        self.other_integration_time = max(
+            0,
+            self.single_frame_time.to(u.s).value * common_frames
+            + self.reset_frame_time.to(u.s).value * self.reset_frames_2,
+        ) * u.s
+
+        self.dropped_integration_time = self.other_integration_time
+
+        bytes_per_frame = max(
+            0, (self.bytes_per_pixel * self.pixels_per_frame).to(u.byte).value
+        ) * u.byte
+
+        if self.average_groups:
+            self.first_integration_saved_frames = self.groups
+            self.other_integration_saved_frames = self.groups
+            self.integration_data = bytes_per_frame * self.groups
+        else:
+            self.first_integration_saved_frames = self.groups * self.read_frames
+            self.other_integration_saved_frames = self.groups * self.read_frames
+            self.integration_data = bytes_per_frame * self.groups * self.read_frames
+
+        self.integration_data = max(
+            0, self.integration_data.to(u.byte).value
+        ) * u.byte
+
+    def update_for_vitl(self, vitl_settling_time: Quantity):
+        """Adjust ``reset_frames_1`` to cover a VITL settling time and recompute.
+
+        Sets ``reset_frames_1`` to the minimum number of reset frames whose
+        total duration is at least ``vitl_settling_time``, then calls
+        ``_update_derived`` to propagate the change.
+
+        Parameters
+        ----------
+        vitl_settling_time : Quantity[second]
+            Minimum time required for VITL detector settling.
+        """
+        # reset_frame_time was resolved from the sentinel during __post_init__,
+        # so it holds the actual frame duration here.
+        if self.reset_frame_time.to(u.s).value == 0.0:
+            self.reset_frames_1 = 1
+        else:
+            self.reset_frames_1 = max(
+                1,
+                math.ceil((vitl_settling_time / self.reset_frame_time).decompose().value),
+            )
+
+        self._update_derived()
+
+    def solve_integrations(
+        self,
+        duration: Quantity,
+        pre_overhead_time: Quantity = 260.0 * u.s,
+        post_overhead_time: Quantity = 102.0 * u.s,
+    ):
+        """Compute the number of integrations that fit within a duration.
+
+        Parameters
+        ----------
+        duration : Quantity[second]
+            Total available observation time.
+        pre_overhead_time : Quantity[second], optional
+            Fixed overhead before science integrations begin.
+        post_overhead_time : Quantity[second], optional
+            Fixed overhead after science integrations end.
+
+        Returns
+        -------
+        integrations : int
+            Number of science integrations that fit in the available time.
+        data : Quantity[byte]
+            Total data volume for those integrations.
+        data_compressed : Quantity[byte]
+            Total compressed data volume.
+        """
+        buffered_time = (
+            duration.to(u.s)
+            - pre_overhead_time.to(u.s)
+            - post_overhead_time.to(u.s)
+            - self.additional_overhead_time.to(u.s)
+        )
+        buffered_time = max(0, buffered_time.value) * u.s
+
+        integrations = 0
+        if self.first_integration_time <= buffered_time:
+            integrations += 1
+            buffered_time -= self.first_integration_time
+
+            if self.other_integration_time <= buffered_time:
+                other_integrations = math.floor(
+                    (buffered_time / self.other_integration_time).value
+                )
+                integrations += other_integrations
+
+        if self.dropped_integrations > 0:
+            integrations = max(0, integrations - self.dropped_integrations)
+
+        data = integrations * self.integration_data
+        return (integrations, data, data * self.compression_ratio)
+
+    def solve_duration(
+        self,
+        integrations: int,
+        pre_overhead_time: Quantity = 260.0 * u.s,
+        post_overhead_time: Quantity = 102.0 * u.s,
+    ):
+        """Compute the total duration required to acquire a given number of integrations.
+
+        Parameters
+        ----------
+        integrations : int
+            Desired number of science integrations.
+        pre_overhead_time : Quantity[second], optional
+            Fixed overhead before science integrations begin.
+        post_overhead_time : Quantity[second], optional
+            Fixed overhead after science integrations end.
+
+        Returns
+        -------
+        duration : Quantity[second]
+            Total wall-clock time needed, including all overheads.
+        data : Quantity[byte]
+            Total data volume for those integrations.
+        data_compressed : Quantity[byte]
+            Total compressed data volume.
+
+        Notes
+        -----
+        ``dropped_integrations`` is intentionally ignored here: when the
+        caller requests a specific integration count, that count is taken
+        as-is rather than changed to compensate for drops.
+        """
+        integrations = max(0, integrations)
+        overhead_time = pre_overhead_time + post_overhead_time + self.additional_overhead_time
+        data = integrations * self.integration_data
+
+        if integrations == 0:
+            duration = 0.0 * u.s
+        elif integrations == 1:
+            duration = self.first_integration_time + overhead_time
+        else:
+            duration = (
+                self.first_integration_time
+                + self.other_integration_time * (integrations - 1)
+                + overhead_time
+            )
+
+        return (duration, data, data * self.compression_ratio)

--- a/src/shortschedule/nirda.py
+++ b/src/shortschedule/nirda.py
@@ -20,12 +20,17 @@ Two integration lengths are tracked: the *first* integration (which uses
 shorter ``reset_frames_2``).
 """
 
+from __future__ import annotations
+
 import math
 from dataclasses import dataclass, field
 
 from astropy import units as u
 from astropy.units import Quantity
 
+from typing import TYPE_CHECKING
+if TYPE_CHECKING:
+    from .overhead import OverheadTiming
 
 @dataclass
 class NirdaData:
@@ -262,8 +267,7 @@ class NirdaData:
     def solve_integrations(
         self,
         duration: Quantity,
-        pre_overhead_time: Quantity = 258.0 * u.s,
-        post_overhead_time: Quantity = 102.0 * u.s,
+        overhead: OverheadTiming = None
     ):
         """Compute the number of integrations that fit within a duration.
 
@@ -271,10 +275,9 @@ class NirdaData:
         ----------
         duration : Quantity[second]
             Total available observation time.
-        pre_overhead_time : Quantity[second], optional
-            Fixed overhead before science integrations begin.
-        post_overhead_time : Quantity[second], optional
-            Fixed overhead after science integrations end.
+        overhead : OverheadTiming, default=None
+            Overhead timings for nirda and visda.
+            If None, then use default overheads.
 
         Returns
         -------
@@ -285,11 +288,17 @@ class NirdaData:
         data_compressed : Quantity[byte]
             Total compressed data volume.
         """
+
+        if overhead is None:
+            # Use default overheads
+            from .overhead import OverheadTiming
+            overhead = OverheadTiming()
+
         buffered_time = (
-            duration.to(u.s)
-            - pre_overhead_time.to(u.s)
-            - post_overhead_time.to(u.s)
-            - self.additional_overhead_time.to(u.s)
+            duration
+            - overhead.nirda_pre_overhead_time
+            - overhead.nirda_post_overhead_time
+            - self.additional_overhead_time
         )
         buffered_time = max(0, buffered_time.value) * u.s
 
@@ -313,8 +322,7 @@ class NirdaData:
     def solve_duration(
         self,
         integrations: int,
-        pre_overhead_time: Quantity = 258.0 * u.s,
-        post_overhead_time: Quantity = 102.0 * u.s,
+        overhead: OverheadTiming = None
     ):
         """Compute the total duration required to acquire a given number of integrations.
 
@@ -322,10 +330,9 @@ class NirdaData:
         ----------
         integrations : int
             Desired number of science integrations.
-        pre_overhead_time : Quantity[second], optional
-            Fixed overhead before science integrations begin.
-        post_overhead_time : Quantity[second], optional
-            Fixed overhead after science integrations end.
+        overhead : OverheadTiming, default=None
+            Overhead timings for nirda and visda.
+            If None, then use default overheads.
 
         Returns
         -------
@@ -343,7 +350,13 @@ class NirdaData:
         as-is rather than changed to compensate for drops.
         """
         integrations = max(0, integrations)
-        overhead_time = pre_overhead_time + post_overhead_time + self.additional_overhead_time
+        
+        if overhead is None:
+            # Use default overheads
+            from .overhead import OverheadTiming
+            overhead = OverheadTiming()
+        
+        overhead_time = overhead.nirda_pre_overhead_time + overhead.nirda_post_overhead_time + self.additional_overhead_time
         data = integrations * self.integration_data
 
         if integrations == 0:

--- a/src/shortschedule/nirda.py
+++ b/src/shortschedule/nirda.py
@@ -75,9 +75,15 @@ class NirdaData:
     compression_ratio : float
         Effective on-board compression factor applied to raw data.
         This is an empirical parameter.
-    reset_frame_time : Quantity[second]
-        Explicit reset-frame duration. A negative value means the reset
-        frame takes the same time as a science frame (``single_frame_time``).
+    global_reset_method : str
+        Per-integration global-reset overhead model. 
+        - ``'off'`` (no outside roi reset; no overhead)
+        - ``'global'`` (outside roi are quickly resetl; a small fixed overhead)
+        - ``'line_by_line'`` (``global_reset_lbl_rows`` rows at ``global_reset_lbl_time_per_row`` each).
+    global_reset_lbl_rows : int
+        Number of reset rows used by the ``'line_by_line'`` method.
+    global_reset_lbl_time_per_row : Quantity[second]
+        Reset time per row used by the ``'line_by_line'`` method.
     additional_overhead_time : Quantity[second]
         Extra fixed overhead beyond ``pre_overhead_time`` and
         ``post_overhead_time`` subtracted before scheduling integrations.
@@ -88,6 +94,8 @@ class NirdaData:
         Total pixels clocked out per frame, including buffer pixels.
     single_frame_time : Quantity[second]
         Wall-clock duration of one detector frame.
+    reset_frame_time : Quantity[second]
+        Reset-frame duration. Derived as equal to ``single_frame_time``.
     first_integration_saved_frames : int
         Frames written to memory for the first integration.
     other_integration_saved_frames : int
@@ -123,8 +131,10 @@ class NirdaData:
     bytes_per_pixel: Quantity = 2 * u.byte
     dropped_integrations: int = 0
     compression_ratio: float = 0.8
-    reset_frame_time: Quantity = -1.0 * u.s
-    additional_overhead_time: Quantity = 2 * u.s
+    global_reset_method: str = 'off'
+    global_reset_lbl_rows: int = 256
+    global_reset_lbl_time_per_row: Quantity = 10.0e-6 * u.s
+    additional_overhead_time: Quantity = 0 * u.s
 
     # Derived attributes: computed in _update_derived, not constructor arguments
     pixels_per_frame: int = field(init=False)
@@ -135,6 +145,7 @@ class NirdaData:
     other_integration_time: Quantity = field(init=False)
     dropped_integration_time: Quantity = field(init=False)
     integration_data: Quantity = field(init=False)
+    reset_frame_time: Quantity = field(init=False)
 
     def __post_init__(self):
         self._update_derived()
@@ -159,23 +170,46 @@ class NirdaData:
             0, (self.pixels_per_frame * self.read_time_per_pixel).to(u.s).value
         ) * u.s
 
-        # Replace the negative sentinel with the actual frame time so that
-        # update_for_vitl can use reset_frame_time directly.
-        if self.reset_frame_time < 0 * u.s:
-            self.reset_frame_time = self.single_frame_time
+        # Assume reset frames take the same as regular frames.
+        self.reset_frame_time = self.single_frame_time
+
+        # Determine common integration time (part that is the same for 1st and subsequent integrations)
+        # There is additional per-integration overhead if a global reset is used.
+        self.global_reset_method = self.global_reset_method.lower().strip()
+        global_reset_overhead = 0.0 * u.s
+        if self.global_reset_method not in ('off', 'global', 'line_by_line'):
+            raise ValueError(f"NIRDA: Unknown global reset method requested: {self.global_reset_method}")
+        elif self.global_reset_method == 'global':
+            # Global reset requires a "negligible compared to frame time" overhead.
+            # This value is not real but just something small.
+            global_reset_overhead = 1.0e-6 * u.s
+        elif self.global_reset_method == 'line_by_line':
+            # Line by line method requires 10us per line.
+            global_reset_overhead = self.global_reset_lbl_time_per_row * self.global_reset_lbl_rows
+
+        # Common integration time in seconds (part shared by 1st and subsequent
+        # integrations). Kept as a plain float here and converted to a Quantity
+        # below, matching the float-then-``* u.s`` style used elsewhere.
+        common_integration_time = max(
+            0,
+            self.single_frame_time.to(u.s).value * common_frames
+            + global_reset_overhead.to(u.s).value
+        )
 
         self.first_integration_time = max(
             0,
-            self.single_frame_time.to(u.s).value * common_frames
+            common_integration_time
             + self.reset_frame_time.to(u.s).value * self.reset_frames_1,
         ) * u.s
 
         self.other_integration_time = max(
             0,
-            self.single_frame_time.to(u.s).value * common_frames
+            common_integration_time
             + self.reset_frame_time.to(u.s).value * self.reset_frames_2,
         ) * u.s
 
+        # If we drop any integrations then the duration of those drops will always be equal to the "other"
+        # integration time.
         self.dropped_integration_time = self.other_integration_time
 
         bytes_per_frame = max(
@@ -207,22 +241,28 @@ class NirdaData:
         vitl_settling_time : Quantity[second]
             Minimum time required for VITL detector settling.
         """
-        # reset_frame_time was resolved from the sentinel during __post_init__,
-        # so it holds the actual frame duration here.
+        # reset_frame_time is derived (equal to single_frame_time) during
+        # __post_init__, so it holds the actual frame duration here.
+        
+        # TODO: Open Question! Do we add the global reset time to this?
+
         if self.reset_frame_time.to(u.s).value == 0.0:
-            self.reset_frames_1 = 1
+            # Have at least 2 reset1
+            self.reset_frames_1 = 2
         else:
             self.reset_frames_1 = max(
                 1,
                 math.ceil((vitl_settling_time / self.reset_frame_time).decompose().value),
             )
 
+        # TODO: Open Question! Do we add the global reset time to this?
+
         self._update_derived()
 
     def solve_integrations(
         self,
         duration: Quantity,
-        pre_overhead_time: Quantity = 260.0 * u.s,
+        pre_overhead_time: Quantity = 258.0 * u.s,
         post_overhead_time: Quantity = 102.0 * u.s,
     ):
         """Compute the number of integrations that fit within a duration.
@@ -273,7 +313,7 @@ class NirdaData:
     def solve_duration(
         self,
         integrations: int,
-        pre_overhead_time: Quantity = 260.0 * u.s,
+        pre_overhead_time: Quantity = 258.0 * u.s,
         post_overhead_time: Quantity = 102.0 * u.s,
     ):
         """Compute the total duration required to acquire a given number of integrations.

--- a/src/shortschedule/nirda.py
+++ b/src/shortschedule/nirda.py
@@ -89,9 +89,13 @@ class NirdaData:
     roi_y_start : int
         Starting row of the ROI on the full detector (pixels).
     roi_x_buffer_pixels : int
-        Extra columns read per row for detector reference pixels.
+        Extra columns read per row for detector reference pixels. These are
+        clocked out (affecting frame time) but are not saved or downlinked,
+        so they do not contribute to data volume.
     roi_y_buffer_pixels : int
-        Extra rows read per frame for detector reference pixels.
+        Extra rows read per frame for detector reference pixels. These are
+        clocked out (affecting frame time) but are not saved or downlinked,
+        so they do not contribute to data volume.
     read_time_per_pixel : Quantity[second]
         Detector clock period per pixel during readout.
     bytes_per_pixel : Quantity[byte]
@@ -117,7 +121,12 @@ class NirdaData:
     Attributes
     ----------
     pixels_per_frame : int
-        Total pixels clocked out per frame, including buffer pixels.
+        Total pixels clocked out per frame, including buffer pixels. Buffer
+        pixels are read out (so they cost time) but are not downlinked, so
+        this is used for timing only.
+    saved_pixels_per_frame : int
+        Science pixels saved per frame (``roi_x_size * roi_y_size``),
+        excluding buffer pixels. This is what drives data volume.
     single_frame_time : Quantity[second]
         Wall-clock duration of one detector frame.
     reset_frame_time : Quantity[second]
@@ -191,6 +200,7 @@ class NirdaData:
 
     # Derived attributes: computed in _update_derived, not constructor arguments
     pixels_per_frame: int = field(init=False)
+    saved_pixels_per_frame: int = field(init=False)
     single_frame_time: Quantity = field(init=False)
     first_integration_saved_frames: int = field(init=False)
     other_integration_saved_frames: int = field(init=False)
@@ -225,11 +235,16 @@ class NirdaData:
             + self.groups * self.read_frames
         )
 
+        # Buffer pixels are clocked out with the ROI (so they cost frame time)
+        # but they are not saved to memory, so they are excluded from the pixel
+        # count used for data volume.
         self.pixels_per_frame = max(
             0,
             (self.roi_x_size + self.roi_x_buffer_pixels)
             * (self.roi_y_size + self.roi_y_buffer_pixels),
         )
+
+        self.saved_pixels_per_frame = max(0, self.roi_x_size * self.roi_y_size)
 
         self.single_frame_time = max(
             0, (self.pixels_per_frame * self.read_time_per_pixel).to(u.s).value
@@ -283,7 +298,7 @@ class NirdaData:
 
         bytes_per_frame = max(
             0,
-            (self.bytes_per_pixel * self.pixels_per_frame).to(u.byte).value
+            (self.bytes_per_pixel * self.saved_pixels_per_frame).to(u.byte).value
         ) * u.byte
 
         if self.average_groups:

--- a/src/shortschedule/overhead.py
+++ b/src/shortschedule/overhead.py
@@ -45,17 +45,20 @@ class OverheadTiming:
         # ... 
         # Observation
         # ...
-        time_delta = 0.0
 
         # Post-Observation COMMANDS:
+        time_delta = 0.0
         # PAYLOAD_HALT_IMAGING_OR_COMMAND_SEQUENCE
         time_delta += 2.0
         # SADA_MODE with SADA_NUM 1, INDEX AUTO_TRACK_QEST
-        time_delta += 20.0
+        time_delta += 40.0
         # GOTO_TARGET Idle
         time_delta += 18.0
         # PAYLOAD_READ close file
+        time_delta += 42.0 # Delta between end of sequence and when MOC considers the slew to idle to be complete.
         # End of Observation
+        self.nirda_post_overhead_time = time_delta
+        self.visda_post_overhead_time = time_delta
 
 
 

--- a/src/shortschedule/overhead.py
+++ b/src/shortschedule/overhead.py
@@ -1,0 +1,65 @@
+
+
+# Class to determine overhead times for visda and nirda observations
+
+import math
+from dataclasses import dataclass, field
+
+from astropy import units as u
+from astropy.units import Quantity
+
+
+@dataclass
+class OverheadTiming:
+
+    nirda_pre_overhead_time: Quantity = field(init=False)
+    visda_pre_overhead_time: Quantity = field(init=False)
+    nirda_post_overhead_time: Quantity = field(init=False)
+    visda_post_overhead_time: Quantity = field(init=False)
+
+    def __post_init__(self):
+        self._update_derived()
+
+    def _update_derived(self):
+
+        # This is the main place to change what happens during sequences
+        # These are the commands that the MOC generates for each observation
+        # based on SOC-provided calendars.
+
+        time_delta = 0.0
+        # COMMANDS:
+        # GOTO_TARGET 
+        time_delta += 2.0
+        # MACRO_EXECUTE 65 
+        time_delta += 20.0  # TODO: We generally say macro65 should run 25 seconds before a read but moc is only doing 20 here.
+        # PAYLOAD_READ
+        time_delta += 186.0
+        # SADA_MODE 1 INDEX STOP
+        time_delta += 50.0
+        # PAYLOAD_ACQUIRE_INF_CAM_IMAGES 
+        self.nirda_pre_overhead_time = time_delta * u.s
+        time_delta += 2.0
+        # PAYLOAD_ACQUIRE_VIS_CAM_SCIENCE_DATA
+        self.visda_pre_overhead_time = time_delta * u.s
+        
+        # ... 
+        # Observation
+        # ...
+        time_delta = 0.0
+
+        # Post-Observation COMMANDS:
+        # PAYLOAD_HALT_IMAGING_OR_COMMAND_SEQUENCE
+        time_delta += 2.0
+        # SADA_MODE with SADA_NUM 1, INDEX AUTO_TRACK_QEST
+        time_delta += 20.0
+        # GOTO_TARGET Idle
+        time_delta += 18.0
+        # PAYLOAD_READ close file
+        # End of Observation
+
+
+
+
+
+
+

--- a/src/shortschedule/overhead.py
+++ b/src/shortschedule/overhead.py
@@ -70,43 +70,45 @@ class OverheadTiming:
         # These are the commands that the MOC generates for each observation
         # based on SOC-provided calendars.
 
-        time_delta = 0.0
+        time_delta = 0.0                                      # 0 s
         # COMMANDS:
         # GOTO_TARGET 
-        time_delta += 2.0
+        time_delta += 2.0                                     # 2 s
         # MACRO_EXECUTE 65 
-        time_delta += 20.0  # TODO: We generally say macro65 should run 25 seconds before a read but moc is only doing 20 here.
+        # TODO: We generally say macro65 should run 25 seconds before a read but moc is only doing 20 here.
+        time_delta += 20.0                                    # 22 s
         # PAYLOAD_READ
-        time_delta += 186.0
+        time_delta += 186.0                                   # 208 s
         # SADA_MODE 1 INDEX STOP
-        time_delta += 50.0
+        time_delta += 50.0                                    # 258 s
         # PAYLOAD_ACQUIRE_INF_CAM_IMAGES 
         if self.nirda_pre_overhead_time is None:
-            self.nirda_pre_overhead_time = time_delta * u.s
-        time_delta += 2.0
+            self.nirda_pre_overhead_time = time_delta * u.s   # 258 s
+        time_delta += 2.0                                     # 260 s
         # PAYLOAD_ACQUIRE_VIS_CAM_SCIENCE_DATA
         if self.visda_pre_overhead_time is None:
-            self.visda_pre_overhead_time = time_delta * u.s
+            self.visda_pre_overhead_time = time_delta * u.s   # 260 s
         
         # ... 
         # Observation
         # ...
 
         # Post-Observation COMMANDS:
-        time_delta = 0.0
+        time_delta = 0.0                                      # 0 s
         # PAYLOAD_HALT_IMAGING_OR_COMMAND_SEQUENCE
-        time_delta += 2.0
+        time_delta += 2.0                                     # 2 s
         # SADA_MODE with SADA_NUM 1, INDEX AUTO_TRACK_QEST
-        time_delta += 40.0
+        time_delta += 40.0                                    # 42 s
         # GOTO_TARGET Idle
-        time_delta += 18.0
+        time_delta += 18.0                                    # 60 s
         # PAYLOAD_READ close file
-        time_delta += 42.0 # Delta between end of sequence and when MOC considers the slew to idle to be complete.
+        # Below is the delta between end of sequence and when MOC considers the slew to idle to be complete.
+        time_delta += 42.0                                    # 102 s
         # End of Observation
         if self.nirda_post_overhead_time is None:
-            self.nirda_post_overhead_time = time_delta * u.s
+            self.nirda_post_overhead_time = time_delta * u.s  # 102 s
         if self.visda_post_overhead_time is None:
-            self.visda_post_overhead_time = time_delta * u.s
+            self.visda_post_overhead_time = time_delta * u.s  # 102 s
 
 
 

--- a/src/shortschedule/overhead.py
+++ b/src/shortschedule/overhead.py
@@ -1,9 +1,27 @@
+"""Observation overhead timing helper.
 
+This module implements ``OverheadTiming``, a dataclass that holds the
+fixed pre- and post-observation overhead times applied to NIRDA and VISDA
+observations. These overheads model the command sequences the MOC
+generates for each observation based on SOC-provided calendars.
 
-# Class to determine overhead times for visda and nirda observations
+Notes
+-----
+The overheads bracket every observation::
 
-import math
-from dataclasses import dataclass, field
+    pre-overhead (slew, macro, read, SADA, acquire) → observation → post-overhead (halt, SADA, slew to idle, close file)
+
+The pre-overhead differs between NIRDA and VISDA because the VISDA science
+acquisition command is issued slightly after the NIRDA imaging command, so
+VISDA accrues a small additional offset. The post-overhead is identical for
+both detectors.
+
+Any value left as ``None`` at construction is filled in with the default
+derived from the modelled command sequence; supplying an explicit
+``Quantity`` overrides the corresponding default.
+"""
+
+from dataclasses import dataclass
 
 from astropy import units as u
 from astropy.units import Quantity
@@ -11,16 +29,42 @@ from astropy.units import Quantity
 
 @dataclass
 class OverheadTiming:
+    """Pre- and post-observation overhead times for NIRDA and VISDA.
 
-    nirda_pre_overhead_time: Quantity = field(init=False)
-    visda_pre_overhead_time: Quantity = field(init=False)
-    nirda_post_overhead_time: Quantity = field(init=False)
-    visda_post_overhead_time: Quantity = field(init=False)
+    Any field left as ``None`` is populated in ``__post_init__`` via
+    ``_update_derived`` with the default value derived from the modelled
+    MOC command sequence. Supplying an explicit ``Quantity`` for a field
+    overrides that default and leaves it untouched.
+
+    Parameters
+    ----------
+    nirda_pre_overhead_time : Quantity[second] or None, default=None
+        Overhead before a NIRDA observation begins. If ``None``, derived
+        from the pre-observation command sequence up to the NIRDA
+        infrared-camera image acquisition.
+    visda_pre_overhead_time : Quantity[second] or None, default=None
+        Overhead before a VISDA observation begins. If ``None``, derived
+        from the pre-observation command sequence up to the VISDA science
+        data acquisition (slightly longer than the NIRDA pre-overhead).
+    nirda_post_overhead_time : Quantity[second] or None, default=None
+        Overhead after a NIRDA observation ends. If ``None``, derived from
+        the post-observation command sequence (halt, SADA, slew to idle,
+        close file).
+    visda_post_overhead_time : Quantity[second] or None, default=None
+        Overhead after a VISDA observation ends. If ``None``, derived from
+        the same post-observation command sequence as NIRDA.
+    """
+
+    nirda_pre_overhead_time: Quantity | None = None
+    visda_pre_overhead_time: Quantity | None = None
+    nirda_post_overhead_time: Quantity | None = None
+    visda_post_overhead_time: Quantity | None = None
 
     def __post_init__(self):
         self._update_derived()
 
     def _update_derived(self):
+        """Fill in any unset overhead times from the modelled MOC sequence."""
 
         # This is the main place to change what happens during sequences
         # These are the commands that the MOC generates for each observation
@@ -37,10 +81,12 @@ class OverheadTiming:
         # SADA_MODE 1 INDEX STOP
         time_delta += 50.0
         # PAYLOAD_ACQUIRE_INF_CAM_IMAGES 
-        self.nirda_pre_overhead_time = time_delta * u.s
+        if self.nirda_pre_overhead_time is None:
+            self.nirda_pre_overhead_time = time_delta * u.s
         time_delta += 2.0
         # PAYLOAD_ACQUIRE_VIS_CAM_SCIENCE_DATA
-        self.visda_pre_overhead_time = time_delta * u.s
+        if self.visda_pre_overhead_time is None:
+            self.visda_pre_overhead_time = time_delta * u.s
         
         # ... 
         # Observation
@@ -57,8 +103,10 @@ class OverheadTiming:
         # PAYLOAD_READ close file
         time_delta += 42.0 # Delta between end of sequence and when MOC considers the slew to idle to be complete.
         # End of Observation
-        self.nirda_post_overhead_time = time_delta
-        self.visda_post_overhead_time = time_delta
+        if self.nirda_post_overhead_time is None:
+            self.nirda_post_overhead_time = time_delta * u.s
+        if self.visda_post_overhead_time is None:
+            self.visda_post_overhead_time = time_delta * u.s
 
 
 

--- a/src/shortschedule/parser.py
+++ b/src/shortschedule/parser.py
@@ -77,6 +77,7 @@ def parse_science_calendar(
             ),
             "created": meta.get("Created"),
             "delivery_id": meta.get("Delivery_Id"),
+            "source_path": str(xml_path),
         }
         if verbose:
             print(
@@ -85,7 +86,7 @@ def parse_science_calendar(
     else:
         if verbose:
             print("Warning: No Meta element found")
-        metadata = {}
+        metadata = {"source_path": str(xml_path)}
 
     # Parse visits using namespace
     visits = []

--- a/src/shortschedule/scheduler.py
+++ b/src/shortschedule/scheduler.py
@@ -424,6 +424,11 @@ class ScheduleProcessor:
                 processed_calendar
             )
 
+        # Renumber visit and observation IDs sequentially. This runs last,
+        # after any merges/time changes that may have dropped IDs, so the
+        # delivered calendar always has contiguous, ordered identifiers.
+        self._renumber_ids(processed_calendar, verbose)
+
         # Analyze processed calendar
         self._analyze_processed_calendar(processed_calendar)
 
@@ -565,6 +570,47 @@ class ScheduleProcessor:
     # Tolerances used when deciding whether two sequences can be merged.
     _MERGE_ADJACENCY_TOL_SEC = 1.0  # max stop-to-start gap (seconds)
     _MERGE_POINTING_TOL_DEG = 1e-6  # max RA/Dec difference (degrees)
+
+    def _renumber_ids(
+        self, calendar: ScienceCalendar, verbose: bool = False
+    ) -> ScienceCalendar:
+        """Renumber visit and observation IDs to be sequential.
+
+        Visits are numbered ``0001``, ``0002``, ... in their current order,
+        and within each visit the observation sequences are numbered
+        ``001``, ``002``, ... in their current order. This is run after all
+        time changes and merges so that any IDs dropped along the way are
+        replaced with a contiguous, ordered set.
+
+        Parameters
+        ----------
+        calendar : ScienceCalendar
+            Calendar whose IDs are renumbered in place.
+        verbose : bool, optional
+            Print the number of IDs changed when True.
+
+        Returns
+        -------
+        ScienceCalendar
+            The same calendar instance, with IDs renumbered.
+        """
+        changed = 0
+        for visit_index, visit in enumerate(calendar.visits, start=1):
+            new_visit_id = f"{visit_index:04d}"
+            if visit.id != new_visit_id:
+                visit.id = new_visit_id
+                changed += 1
+
+            for seq_index, seq in enumerate(visit.sequences, start=1):
+                new_seq_id = f"{seq_index:03d}"
+                if seq.id != new_seq_id:
+                    seq.id = new_seq_id
+                    changed += 1
+
+        if verbose:
+            print(f"Renumbered IDs: {changed} identifier(s) updated.")
+
+        return calendar
 
     def _merge_similar_observations(
         self, calendar: ScienceCalendar, verbose: bool = False

--- a/src/shortschedule/scheduler.py
+++ b/src/shortschedule/scheduler.py
@@ -259,6 +259,7 @@ class ScheduleProcessor:
         calendar: ScienceCalendar,
         window_start: Optional[Any] = None,
         window_duration_days: int = 21,
+        merge_similar_observations: bool = False,
         verbose: bool = False,
     ) -> ScienceCalendar:
         """Process a `ScienceCalendar` and return an updated calendar.
@@ -283,6 +284,11 @@ class ScheduleProcessor:
             ISO string or Time object indicating the window start.
         window_duration_days : int, optional
             Number of days to include in the processing window.
+        merge_similar_observations : bool, optional
+            When True, adjacent observation sequences in the same visit that
+            share the same target and pointing are merged into a single
+            longer sequence.
+            Defaults to False.
         verbose : bool, optional
             Print diagnostics when True.
 
@@ -327,6 +333,20 @@ class ScheduleProcessor:
             verbose=verbose,
             precomputed_rolls=self._computed_target_rolls,
         )
+
+        # Optionally merge back-to-back same-target sequences within each
+        # visit. This runs *after* all gap-filling, trimming, and other
+        # duration/timing adjustments so it operates on the final scheduled
+        # boundaries. Because merging extends a sequence over its neighbor,
+        # the merged sequences' payload integration counts are recomputed
+        # for their new combined durations.
+        if merge_similar_observations:
+            processed_calendar = self._merge_similar_observations(
+                processed_calendar, verbose
+            )
+            processed_calendar = self._update_payload_parameters(
+                processed_calendar
+            )
 
         # Analyze processed calendar
         self._analyze_processed_calendar(processed_calendar)
@@ -465,6 +485,104 @@ class ScheduleProcessor:
         return ScienceCalendar(
             metadata=calendar.metadata, visits=windowed_visits
         )
+
+    # Tolerances used when deciding whether two sequences can be merged.
+    _MERGE_ADJACENCY_TOL_SEC = 1.0  # max stop-to-start gap (seconds)
+    _MERGE_POINTING_TOL_DEG = 1e-6  # max RA/Dec difference (degrees)
+
+    def _merge_similar_observations(
+        self, calendar: ScienceCalendar, verbose: bool = False
+    ) -> ScienceCalendar:
+        """Merge back-to-back same-target sequences within each visit.
+
+        Two consecutive sequences (in start-time order) inside the same
+        visit are merged when they:
+
+        1. belong to the same visit (sequences are grouped per visit),
+        2. observe the same target with the same pointing (RA/Dec), and
+        3. are contiguous in time, the second sequence starts at (within
+           a tolerance of) the first sequence's stop time.
+
+        The merged sequence keeps the first sequence's identity, priority,
+        and payload parameters, and extends its ``stop_time`` to the second
+        sequence's ``stop_time``. Merging is applied transitively, so a run
+        of three or more contiguous same-target sequences collapses into a
+        single sequence.
+
+        Parameters
+        ----------
+        calendar : ScienceCalendar
+            Calendar to merge in place-safe fashion (a new calendar with
+            new visits/sequences is returned; the input is not mutated).
+        verbose : bool, optional
+            If True, print a line for each merge performed.
+
+        Returns
+        -------
+        ScienceCalendar
+            Calendar with eligible sequences merged.
+        """
+        merged_count = 0
+        new_visits: List[Visit] = []
+
+        for visit in calendar.visits:
+            # Process sequences in chronological order so "right after each
+            # other" is well defined regardless of input ordering.
+            ordered = sorted(visit.sequences, key=lambda s: s.start_time)
+
+            merged_sequences: List[ObservationSequence] = []
+            for seq in ordered:
+                if merged_sequences and self._can_merge(merged_sequences[-1], seq):
+                    # Extend the previous (kept) sequence over this one.
+                    previous = merged_sequences[-1]
+                    if verbose:
+                        print(
+                            f"Merging visit {visit.id} sequence {seq.id} "
+                            f"into {previous.id} "
+                            f"(target {previous.target}): stop "
+                            f"{previous.stop_time_str} -> {seq.stop_time_str}"
+                        )
+                    previous.stop_time = seq.stop_time
+                    merged_count += 1
+                else:
+                    # Copy so the returned calendar never aliases the input.
+                    merged_sequences.append(seq.copy())
+
+            new_visits.append(Visit(id=visit.id, sequences=merged_sequences))
+
+        if verbose:
+            print(
+                f"Merged {merged_count} similar observation sequence(s) "
+                f"across {len(calendar.visits)} visit(s)."
+            )
+
+        return ScienceCalendar(
+            metadata=calendar.metadata,
+            visits=new_visits,
+            visibility=calendar.visibility,
+        )
+
+    def _can_merge(
+        self, first: ObservationSequence, second: ObservationSequence
+    ) -> bool:
+        """Return True if ``second`` can be merged into ``first``.
+
+        See :meth:`_merge_similar_observations` for the merge criteria.
+        """
+        # Same target (case-insensitive, whitespace-insensitive).
+        if (first.target or "").strip().lower() != (second.target or "").strip().lower():
+            return False
+
+        # Same pointing.
+        if (
+            abs(first.ra - second.ra) > self._MERGE_POINTING_TOL_DEG
+            or abs(first.dec - second.dec) > self._MERGE_POINTING_TOL_DEG
+        ):
+            return False
+
+        # Contiguous in time: second starts when first stops.
+        gap_sec = (second.start_time - first.stop_time).sec
+        return abs(gap_sec) <= self._MERGE_ADJACENCY_TOL_SEC
 
     def _process_all_sequences(
         self, calendar: ScienceCalendar, verbose: bool = False

--- a/src/shortschedule/scheduler.py
+++ b/src/shortschedule/scheduler.py
@@ -2070,18 +2070,50 @@ class ScheduleProcessor:
             return {"times": [], "assignments": [], "summary": {}}
 
         # Time tolerance for comparisons (1 second)
-        time_tolerance = 1.0 * u.s
+        tol = 1.0  # seconds
 
-        # Generate time grid
-        times = []
+        # Build the minute grid once (vectorised). Both materialising scalar
+        # Time objects (``list(times)``) and per-scalar ``isot`` formatting
+        # are very slow, so keep ``times`` as a single Time array and format
+        # all ISOT strings in one vectorised call.
+        times = start_time + np.arange(total_minutes) * u.min
+        isot_values = np.atleast_1d(times.isot)
+
+        # Pre-compute each sequence's [start, stop) window in seconds relative
+        # to ``start_time``, sorted by start. Doing the (slow) astropy Time
+        # subtraction once per sequence — rather than once per (minute,
+        # sequence) — and then walking a forward pointer keeps this O(minutes
+        # + sequences) instead of O(minutes * sequences). The latter is why
+        # the per-minute scan slowed down as it advanced through the window:
+        # each later minute had to skip every already-finished sequence
+        # before reaching its owner.
+        intervals = []
+        for visit in calendar.visits:
+            for seq in visit.sequences:
+                s0 = (seq.start_time - start_time).to(u.s).value
+                s1 = (seq.stop_time - start_time).to(u.s).value
+                intervals.append((s0, s1, seq, visit.id))
+        intervals.sort(key=lambda iv: iv[0])
+        n_intervals = len(intervals)
+
         assignments = []
+        lo = 0  # index of the earliest sequence that may still own a minute
 
-        for minute_idx in range(total_minutes):
-            current_time = start_time + minute_idx * u.min
-            times.append(current_time)
+        for minute_idx in self._progress(
+            range(total_minutes),
+            desc="Mapping minute assignments",
+            total=total_minutes,
+        ):
+            current = float(minute_idx) * 60.0
+
+            # Retire sequences whose window has ended: once a minute is at or
+            # past stop - tol, that sequence (and, by sort order, none before
+            # it) can own this or any later minute.
+            while lo < n_intervals and current >= intervals[lo][1] - tol:
+                lo += 1
 
             assignment = {
-                "time": current_time.isot,
+                "time": isot_values[minute_idx],
                 "minute_index": minute_idx,
                 "sequence_id": None,
                 "target": None,
@@ -2092,39 +2124,23 @@ class ScheduleProcessor:
                 "status": "unassigned",
             }
 
-            # Find the sequence that owns this minute
-            assigned_sequence = None
-            visit_id = None
-
-            for visit in calendar.visits:
-                for seq in visit.sequences:
-                    start_diff = current_time - seq.start_time
-                    stop_diff = current_time - seq.stop_time
-
-                    starts_at_or_after = start_diff >= -time_tolerance
-                    ends_before = stop_diff < -time_tolerance
-                    starts_exactly = abs(start_diff) <= time_tolerance
-
-                    if (starts_at_or_after and ends_before) or starts_exactly:
-                        assigned_sequence = seq
-                        visit_id = visit.id
-                        break
-
-                if assigned_sequence:
-                    break
-
-            if assigned_sequence:
-                assignment.update(
-                    {
-                        "sequence_id": assigned_sequence.id,
-                        "target": assigned_sequence.target,
-                        "visit_id": visit_id,
-                        "ra": assigned_sequence.ra,
-                        "dec": assigned_sequence.dec,
-                        "priority": assigned_sequence.priority,
-                        "status": "assigned",
-                    }
-                )
+            if lo < n_intervals:
+                s0, s1, seq, visit_id = intervals[lo]
+                starts_at_or_after = current >= s0 - tol
+                ends_before = current < s1 - tol
+                starts_exactly = abs(current - s0) <= tol
+                if (starts_at_or_after and ends_before) or starts_exactly:
+                    assignment.update(
+                        {
+                            "sequence_id": seq.id,
+                            "target": seq.target,
+                            "visit_id": visit_id,
+                            "ra": seq.ra,
+                            "dec": seq.dec,
+                            "priority": seq.priority,
+                            "status": "assigned",
+                        }
+                    )
 
             assignments.append(assignment)
 

--- a/src/shortschedule/scheduler.py
+++ b/src/shortschedule/scheduler.py
@@ -15,6 +15,7 @@ are provided. The processor performs these high-level steps:
 # Standard library
 import copy
 import uuid
+import warnings
 from copy import deepcopy
 from typing import Any, Dict, List, Optional, Tuple
 
@@ -70,6 +71,8 @@ class ScheduleProcessor:
         nirda_post_sequence_overhead: u.Quantity | None = None,
         override_nirda_parameters: Optional[Dict[int, List[str]]] = None,
         override_visda_parameters: Optional[Dict[int, List[str]]] = None,
+        max_file_size_uncompressed: u.Quantity = 830.0 * 1000 * 1000 * u.byte,
+        max_file_size_compressed: u.Quantity = 255.0 * 1000 * 1000 * u.byte,
         moon_min: Optional[float] = 20.0,
         sun_min: Optional[float] = 91.0,
         earthlimb_min: Optional[float] = 20.0,
@@ -123,6 +126,16 @@ class ScheduleProcessor:
             ``override_nirda_parameters`` but using ``VisdaData`` field
             names (e.g. ``frames_per_coadd``, ``exposure_time_s``).
             Defaults to no overrides.
+        max_file_size_uncompressed : Quantity[byte], optional
+            Maximum allowed *uncompressed* data volume per detector per
+            sequence. A warning is raised during the payload-update step if a
+            sequence's computed NIRDA or VISDA data exceeds this.
+            Defaults to 830 MB.
+        max_file_size_compressed : Quantity[byte], optional
+            Maximum allowed *compressed* data volume per detector per
+            sequence. A warning is raised if a sequence's computed compressed
+            NIRDA or VISDA data exceeds this.
+            Defaults to 255 MB.
         moon_min, sun_min, earthlimb_min, mars_min, jupiter_min : float, optional
             Minimum angular separations (degrees) for visibility constraints.
         earthlimb_day_min : float, optional
@@ -270,6 +283,12 @@ class ScheduleProcessor:
         self._override_visda_parameters: Dict[int, List[str]] = (
             override_visda_parameters or {}
         )
+
+        # Per-observation data-volume limits. A warning is raised during the
+        # payload-update step if a sequence's computed NIRDA/VISDA data
+        # exceeds these.
+        self.max_file_size_uncompressed = max_file_size_uncompressed
+        self.max_file_size_compressed = max_file_size_compressed
 
         # Enhanced gap tracking with before/after comparison
         self.gap_report = {
@@ -2059,6 +2078,51 @@ class ScheduleProcessor:
             return None, missing
         return data_cls(**kwargs), writeback
 
+    def _warn_if_data_exceeds_limits(
+        self,
+        sequence: ObservationSequence,
+        detector: str,
+        data: u.Quantity,
+        data_compressed: u.Quantity,
+    ) -> None:
+        """Warn if a sequence's computed data volume exceeds the limits.
+
+        Compares the *uncompressed* ``data`` against
+        ``max_file_size_uncompressed`` and the *compressed*
+        ``data_compressed`` against ``max_file_size_compressed``, emitting a
+        ``UserWarning`` for each limit that is exceeded.
+        """
+        max_uncompressed = getattr(self, "max_file_size_uncompressed", None)
+        max_compressed = getattr(self, "max_file_size_compressed", None)
+
+        seq_id = (
+            f"{detector} sequence {sequence.id} "
+            f"({sequence.target} @ {sequence.start_time.isot})"
+        )
+
+        if (
+            max_uncompressed is not None
+            and data.to(u.byte).value > max_uncompressed.to(u.byte).value
+        ):
+            warnings.warn(
+                f"{seq_id}: uncompressed data "
+                f"{data.to(u.byte).value / 1e6:.1f} MB exceeds limit "
+                f"{max_uncompressed.to(u.byte).value / 1e6:.1f} MB",
+                stacklevel=2,
+            )
+
+        if (
+            max_compressed is not None
+            and data_compressed.to(u.byte).value
+            > max_compressed.to(u.byte).value
+        ):
+            warnings.warn(
+                f"{seq_id}: compressed data "
+                f"{data_compressed.to(u.byte).value / 1e6:.1f} MB exceeds "
+                f"limit {max_compressed.to(u.byte).value / 1e6:.1f} MB",
+                stacklevel=2,
+            )
+
     def _update_payload_parameters_sequence(
         self, sequence: ObservationSequence
     ) -> ObservationSequence:
@@ -2132,7 +2196,12 @@ class ScheduleProcessor:
             visda_pre_overhead_time=pre_sequence_overhead.to(u.s),
             visda_post_overhead_time=post_sequence_overhead.to(u.s),
         )
-        frames, _, _ = visda.solve_integrations(duration.to(u.s), overhead)
+        frames, data, data_compressed = visda.solve_integrations(
+            duration.to(u.s), overhead
+        )
+        self._warn_if_data_exceeds_limits(
+            sequence, "VISDA", data, data_compressed
+        )
 
         success = sequence.set_payload_parameter(
             "AcquireVisCamScienceData",
@@ -2188,8 +2257,11 @@ class ScheduleProcessor:
             nirda_pre_overhead_time=pre_sequence_overhead.to(u.s),
             nirda_post_overhead_time=post_sequence_overhead.to(u.s),
         )
-        integrations, _, _ = nirda.solve_integrations(
+        integrations, data, data_compressed = nirda.solve_integrations(
             duration.to(u.s), overhead
+        )
+        self._warn_if_data_exceeds_limits(
+            sequence, "NIRDA", data, data_compressed
         )
 
         success = sequence.set_payload_parameter(

--- a/src/shortschedule/scheduler.py
+++ b/src/shortschedule/scheduler.py
@@ -17,7 +17,9 @@ import copy
 import logging
 import uuid
 import warnings
+from collections import defaultdict
 from copy import deepcopy
+from datetime import datetime, timedelta
 from pathlib import Path
 from typing import Any, Dict, List, Optional, Tuple
 
@@ -2819,6 +2821,366 @@ class ScheduleProcessor:
         vis_bar.close()
 
         return issues
+
+    # ------------------------------------------------------------------
+    # Per-day diagnostics (.diag)
+    # ------------------------------------------------------------------
+    @staticmethod
+    def _diag_choose_day(start_dt: datetime, stop_dt: datetime) -> str:
+        """Assign an observation to the UTC day with the largest overlap."""
+        if stop_dt <= start_dt:
+            return start_dt.date().isoformat()
+        day_seconds: Dict[str, float] = defaultdict(float)
+        cursor = start_dt
+        while cursor < stop_dt:
+            next_midnight = datetime(
+                cursor.year, cursor.month, cursor.day
+            ) + timedelta(days=1)
+            chunk_end = min(next_midnight, stop_dt)
+            day_seconds[cursor.date().isoformat()] += (
+                chunk_end - cursor
+            ).total_seconds()
+            cursor = chunk_end
+        return max(day_seconds.items(), key=lambda kv: kv[1])[0]
+
+    @staticmethod
+    def _fits_files_for_sequence(
+        seq: ObservationSequence,
+        overhead: OverheadTiming,
+        nirda: Optional[NirdaData],
+        sc_integrations: int,
+        visda: Optional[VisdaData],
+        num_total_frames: int,
+    ) -> List[str]:
+        """Return the FITS product filenames packaged in a sequence's ``.bin``.
+
+        Names follow the Pandora flight-software conventions (InfImg from
+        ``MACIEMain.cpp``, VisSci from ``PCOCameraMain.cpp``) built from the
+        observation's payload parameters. The per-detector capture-start
+        timestamps are the sequence start plus the detector pre-overhead.
+        """
+        files: List[str] = []
+        target = seq.target
+
+        # NIRDA: InfImg cube (only if integrations were scheduled).
+        if nirda is not None and sc_integrations > 0:
+            nir_start = (
+                seq.start_time + overhead.nirda_pre_overhead_time.to(u.s)
+            ).datetime
+            nir_date = nir_start.strftime("%Y-%m-%d__%H-%M-%S")
+            cube_depth = sc_integrations * nirda.groups
+            files.append(
+                f"{nir_date}_InfImg_{target}_"
+                f"d{nirda.roi_x_size:04d}x{nirda.roi_y_size:04d}"
+                f"x{cube_depth:04d}_b1_e01"
+                f"_i{sc_integrations:02d}_g{nirda.groups:02d}"
+                f"_d{nirda.drop_frames_2:02d}_r{nirda.read_frames:02d}.fits"
+            )
+
+        # VISDA: VisSci cube (only if frames were requested).
+        if visda is not None and num_total_frames > 0:
+            vis_start = (
+                seq.start_time + overhead.visda_pre_overhead_time.to(u.s)
+            ).datetime
+            vis_date = vis_start.strftime("%Y-%m-%d__%H-%M-%S")
+            exp_us = int(visda.exposure_time_s.to(u.us).value)
+            files.append(
+                f"{vis_date}_VisSci_{target}_"
+                f"d{visda.roi_dimension:03d}_n{visda.num_rois:03d}"
+                f"_f{num_total_frames:05d}_e{exp_us:09d}us.fits"
+            )
+
+        # Engineering housekeeping file (timestamp only; downlink time is not
+        # known here, so the sequence start is used as a best-effort stamp).
+        eng_date = seq.start_time.datetime.strftime("%Y_%m_%dT%H_%M_%S")
+        files.append(f"{eng_date}_engineering.fits")
+
+        return files
+
+    def generate_diagnostics(
+        self,
+        calendar: ScienceCalendar,
+        output_path: Optional[Any] = None,
+        pass_data_volume_mb: Optional[float] = None,
+    ) -> str:
+        """Build a per-day ``.diag`` report and (optionally) write it.
+
+        Mirrors the legacy CalendarCleaner diagnostic: a week summary
+        followed by a per-day breakdown of observation counts (by priority),
+        unique targets, NIR/VIS frame and data totals (compressed and
+        uncompressed), observing/gap minutes (with percentages), and a
+        per-day file manifest. Data volumes are computed from the
+        ``NirdaData``/``VisdaData`` models built from each observation's
+        payload, so they stay consistent with the scheduler.
+
+        Parameters
+        ----------
+        calendar : ScienceCalendar
+            Calendar to summarize (typically the processed calendar).
+        output_path : str or pathlib.Path, optional
+            Where to write the ``.diag`` file (its suffix is forced to
+            ``.diag``). If omitted, the calendar's ``source_path`` metadata
+            is used; if that is also missing, nothing is written and only
+            the text is returned.
+        pass_data_volume_mb : float, optional
+            Downlink volume of a single pass (MB). When given, "Required
+            Passes" is reported; otherwise it shows "N/A".
+
+        Returns
+        -------
+        str
+            The full diagnostic text.
+        """
+        mib = 1024.0 * 1024.0
+
+        def fmt(value: float) -> str:
+            value = float(value)
+            if value.is_integer():
+                return str(int(value))
+            return f"{value:.3f}".rstrip("0").rstrip(".")
+
+        def data_str(data_bytes: float) -> str:
+            data_mb = data_bytes / mib
+            if pass_data_volume_mb and pass_data_volume_mb > 0:
+                passes = data_mb / pass_data_volume_mb
+                return f"{fmt(data_mb)} MB (Required Passes: {fmt(passes)})"
+            return f"{fmt(data_mb)} MB (Required Passes: N/A)"
+
+        def to_int(value: Any) -> int:
+            try:
+                return int(float(value))
+            except (TypeError, ValueError):
+                return 0
+
+        def new_bucket() -> Dict[str, Any]:
+            return {
+                "count": 0,
+                "priority_counts": {0: 0, 1: 0, 2: 0},
+                "targets": set(),
+                "nir_frames": 0,
+                "vis_frames": 0,
+                "nir_data": 0.0,
+                "vis_data": 0.0,
+                "nir_data_unc": 0.0,
+                "vis_data_unc": 0.0,
+                "timelines": [],
+                "manifest": [],
+            }
+
+        daily: Dict[str, Dict[str, Any]] = {}
+
+        # Per-detector capture-start offsets for FITS filenames.
+        overhead = getattr(self, "overhead", None) or OverheadTiming()
+
+        for visit in calendar.visits:
+            for seq in visit.sequences:
+                start_dt = seq.start_time.datetime
+                stop_dt = seq.stop_time.datetime
+                day = self._diag_choose_day(start_dt, stop_dt)
+                bucket = daily.setdefault(day, new_bucket())
+
+                bucket["count"] += 1
+                if seq.priority in bucket["priority_counts"]:
+                    bucket["priority_counts"][seq.priority] += 1
+                bucket["targets"].add(seq.target)
+                bucket["timelines"].append((start_dt, stop_dt))
+
+                # NIRDA frames + data from the NirdaData model.
+                nirda, _ = self._build_payload_data(seq, (), NirdaData)
+                sc_integrations = to_int(
+                    seq.get_payload_parameter(
+                        "AcquireInfCamImages", "SC_Integrations"
+                    )
+                )
+                if nirda is not None and sc_integrations > 0:
+                    nir_frames = (
+                        sc_integrations
+                        * nirda.other_integration_saved_frames
+                    )
+                    nir_unc = (
+                        sc_integrations * nirda.integration_data
+                    ).to(u.byte).value
+                    bucket["nir_frames"] += int(nir_frames)
+                    bucket["nir_data_unc"] += nir_unc
+                    bucket["nir_data"] += nir_unc * nirda.compression_ratio
+
+                # VISDA frames (coadds) + data from the VisdaData model.
+                visda, _ = self._build_payload_data(
+                    seq,
+                    (),
+                    VisdaData,
+                    extra_kwargs={"read_time_per_frame_s": 0 * u.s},
+                )
+                num_total_frames = to_int(
+                    seq.get_payload_parameter(
+                        "AcquireVisCamScienceData", "NumTotalFramesRequested"
+                    )
+                )
+                if visda is not None and num_total_frames > 0:
+                    coadds = (
+                        num_total_frames // visda.frames_per_coadd
+                        if visda.frames_per_coadd > 0
+                        else num_total_frames
+                    )
+                    vis_unc = (coadds * visda.frame_bytes).to(u.byte).value
+                    bucket["vis_frames"] += int(coadds)
+                    bucket["vis_data_unc"] += vis_unc
+                    bucket["vis_data"] += vis_unc * visda.compression_ratio
+
+                # Manifest: the downlinked .bin plus the individual FITS
+                # products it contains (named from payload parameters).
+                stamp = start_dt.strftime("%Y%m%dT%H%M%S")
+                bin_path = f"/mnt/data/sci/{stamp}_{seq.target}.bin"
+                fits_files = self._fits_files_for_sequence(
+                    seq,
+                    overhead,
+                    nirda,
+                    sc_integrations,
+                    visda,
+                    num_total_frames,
+                )
+                bucket["manifest"].append((bin_path, fits_files))
+
+        text = self._render_diagnostics(daily, fmt, data_str)
+
+        # Resolve where to write the .diag file.
+        base = output_path
+        if base is None:
+            base = (calendar.metadata or {}).get("source_path")
+        if base is not None:
+            diag_path = Path(base).with_suffix(".diag")
+            diag_path.write_text(text, encoding="utf-8")
+            self._print(f"Wrote diagnostics to {diag_path}")
+
+        return text
+
+    @staticmethod
+    def _diag_observing_and_gaps(timelines: List[Tuple]) -> Tuple[float, float]:
+        """Return (observing_minutes, gap_minutes) for a day's timelines."""
+        observing = 0.0
+        gaps = 0.0
+        previous_stop = None
+        for start_dt, stop_dt in sorted(timelines, key=lambda t: (t[0], t[1])):
+            observing += max(0.0, (stop_dt - start_dt).total_seconds() / 60.0)
+            if previous_stop is not None and start_dt > previous_stop:
+                gaps += (start_dt - previous_stop).total_seconds() / 60.0
+            previous_stop = (
+                stop_dt
+                if previous_stop is None
+                else max(previous_stop, stop_dt)
+            )
+        return observing, gaps
+
+    def _render_diagnostics(self, daily, fmt, data_str) -> str:
+        """Render the diagnostic text from the per-day buckets."""
+        sorted_days = sorted(daily.keys())
+        if not sorted_days:
+            return "No observations were available for diagnostic generation.\n"
+
+        def pct(part: float, whole: float) -> str:
+            return f"{(100.0 * part / whole):.1f}" if whole > 0 else "0.0"
+
+        # Finalize per-day observing/gap minutes and accumulate week totals.
+        summary = {
+            "count": 0,
+            "priority_counts": {0: 0, 1: 0, 2: 0},
+            "nir_data": 0.0,
+            "vis_data": 0.0,
+            "nir_data_unc": 0.0,
+            "vis_data_unc": 0.0,
+            "observing": 0.0,
+            "gaps": 0.0,
+        }
+        for day in sorted_days:
+            item = daily[day]
+            observing, gaps = self._diag_observing_and_gaps(item["timelines"])
+            item["observing"] = observing
+            item["gaps"] = gaps
+            summary["count"] += item["count"]
+            for p in (0, 1, 2):
+                summary["priority_counts"][p] += item["priority_counts"][p]
+            summary["nir_data"] += item["nir_data"]
+            summary["vis_data"] += item["vis_data"]
+            summary["nir_data_unc"] += item["nir_data_unc"]
+            summary["vis_data_unc"] += item["vis_data_unc"]
+            summary["observing"] += observing
+            summary["gaps"] += gaps
+
+        lines: List[str] = []
+
+        # ── Week summary ───────────────────────────────────────────
+        sum_total = summary["nir_data"] + summary["vis_data"]
+        sum_total_unc = summary["nir_data_unc"] + summary["vis_data_unc"]
+        sum_span = summary["observing"] + summary["gaps"]
+        lines.append(
+            f"Calendar Summary {sorted_days[0]} : {sorted_days[-1]}"
+        )
+        lines.append(f"Total Observations: {summary['count']}")
+        lines.append(f"  - Priority 0 = {summary['priority_counts'][0]}")
+        lines.append(f"  - Priority 1 = {summary['priority_counts'][1]}")
+        lines.append(f"  - Priority 2 = {summary['priority_counts'][2]}")
+        lines.append(
+            f"Total Gaps: {fmt(summary['gaps'])} Mins "
+            f"({pct(summary['gaps'], sum_span)}%)"
+        )
+        lines.append(
+            f"Total Observing: {fmt(summary['observing'])} Mins "
+            f"({pct(summary['observing'], sum_span)}%)"
+        )
+        lines.append("Total NIR Data = " + data_str(summary["nir_data"]))
+        lines.append("Total Vis Data = " + data_str(summary["vis_data"]))
+        lines.append("Total Data = " + data_str(sum_total))
+        lines.append("Uncompressed Data")
+        lines.append("Total NIR Data = " + data_str(summary["nir_data_unc"]))
+        lines.append("Total Vis Data = " + data_str(summary["vis_data_unc"]))
+        lines.append("Total Data = " + data_str(sum_total_unc))
+        lines.append("")
+
+        # ── Per-day breakdown ──────────────────────────────────────
+        for day in sorted_days:
+            item = daily[day]
+            day_total = item["nir_data"] + item["vis_data"]
+            day_total_unc = item["nir_data_unc"] + item["vis_data_unc"]
+            span = item["observing"] + item["gaps"]
+
+            lines.append(day)
+            lines.append(f"Number of Observations: {item['count']}")
+            lines.append(f"  - Priority 0 = {item['priority_counts'][0]}")
+            lines.append(f"  - Priority 1 = {item['priority_counts'][1]}")
+            lines.append(f"  - Priority 2 = {item['priority_counts'][2]}")
+            lines.append("List of Unique Targets:")
+            for target in sorted(item["targets"]):
+                lines.append(f"  - {target}")
+            lines.append(f"Total NIR Frames = {fmt(item['nir_frames'])}")
+            lines.append(f"Total Vis Frames = {fmt(item['vis_frames'])}")
+            lines.append(
+                f"Total Gaps: {fmt(item['gaps'])} Mins "
+                f"({pct(item['gaps'], span)}%)"
+            )
+            lines.append(
+                f"Total Observing: {fmt(item['observing'])} Mins "
+                f"({pct(item['observing'], span)}%)"
+            )
+            lines.append("Total NIR Data = " + data_str(item["nir_data"]))
+            lines.append("Total Vis Data = " + data_str(item["vis_data"]))
+            lines.append("Total Data = " + data_str(day_total))
+            lines.append("Uncompressed Data")
+            lines.append("Total NIR Data = " + data_str(item["nir_data_unc"]))
+            lines.append("Total Vis Data = " + data_str(item["vis_data_unc"]))
+            lines.append("Total Data = " + data_str(day_total_unc))
+            lines.append("")
+            lines.append("Manifest of Files for the Day:")
+            for bin_path, fits_files in sorted(
+                item["manifest"], key=lambda entry: entry[0]
+            ):
+                lines.append(f"- {bin_path}")
+                for fits_name in fits_files:
+                    lines.append(f"\t- {fits_name}")
+            lines.append("")
+            lines.append("----")
+            lines.append("")
+
+        return "\n".join(lines).rstrip() + "\n"
 
     def validate_target_names(
         self, calendar: ScienceCalendar, report_issues: bool = True

--- a/src/shortschedule/scheduler.py
+++ b/src/shortschedule/scheduler.py
@@ -73,6 +73,8 @@ class ScheduleProcessor:
         override_visda_parameters: Optional[Dict[int, List[str]]] = None,
         max_file_size_uncompressed: u.Quantity = 830.0 * 1000 * 1000 * u.byte,
         max_file_size_compressed: u.Quantity = 255.0 * 1000 * 1000 * u.byte,
+        update_nirda_reset1_for_vitl: bool = True,
+        vitl_settling_time: u.Quantity = 60.0 * u.s,
         moon_min: Optional[float] = 20.0,
         sun_min: Optional[float] = 91.0,
         earthlimb_min: Optional[float] = 20.0,
@@ -136,6 +138,14 @@ class ScheduleProcessor:
             sequence. A warning is raised if a sequence's computed compressed
             NIRDA or VISDA data exceeds this.
             Defaults to 255 MB.
+        update_nirda_reset1_for_vitl : bool, optional
+            When True (default), each NIRDA observation's ``reset_frames_1``
+            is adjusted via ``NirdaData.update_for_vitl`` to cover
+            ``vitl_settling_time`` before its integration count is computed,
+            and the resulting ``SC_Resets1`` is written back to the payload.
+        vitl_settling_time : Quantity[second], optional
+            Minimum VITL detector settling time used when
+            ``update_nirda_reset1_for_vitl`` is True. Defaults to 60 s.
         moon_min, sun_min, earthlimb_min, mars_min, jupiter_min : float, optional
             Minimum angular separations (degrees) for visibility constraints.
         earthlimb_day_min : float, optional
@@ -289,6 +299,12 @@ class ScheduleProcessor:
         # exceeds these.
         self.max_file_size_uncompressed = max_file_size_uncompressed
         self.max_file_size_compressed = max_file_size_compressed
+
+        # VITL settling: when enabled, each NIRDA observation has its
+        # reset_frames_1 adjusted to cover vitl_settling_time before its
+        # integration count is computed.
+        self.update_nirda_reset1_for_vitl = update_nirda_reset1_for_vitl
+        self.vitl_settling_time = vitl_settling_time
 
         # Enhanced gap tracking with before/after comparison
         self.gap_report = {
@@ -2265,6 +2281,21 @@ class ScheduleProcessor:
         # Write any overridden parameters back onto the observation.
         for tag, text in info.items():
             sequence.set_payload_parameter("AcquireInfCamImages", tag, text)
+
+        # Optionally adjust reset_frames_1 to cover the VITL settling time
+        # before computing integrations, and persist the new SC_Resets1.
+        # This affects number of integrations so needs to be set before 
+        # those are calculated.
+        if getattr(self, "update_nirda_reset1_for_vitl", False):
+            vitl_settling_time = getattr(
+                self, "vitl_settling_time", 60.0 * u.s
+            )
+            nirda.update_for_vitl(vitl_settling_time)
+            sequence.set_payload_parameter(
+                "AcquireInfCamImages",
+                "SC_Resets1",
+                str(int(nirda.reset_frames_1)),
+            )
 
         integrations, data, data_compressed = nirda.solve_integrations(
             duration.to(u.s), overhead

--- a/src/shortschedule/scheduler.py
+++ b/src/shortschedule/scheduler.py
@@ -66,6 +66,7 @@ from .visda import VisdaData
 # by the ``fix_bad_data`` pass.
 BAD_NAME_SYMBOLS = {
     "+": "_",
+    " ": "_",
 }
 
 # Tag names whose values are expected to be non-numeric (names, IDs,
@@ -499,6 +500,13 @@ class ScheduleProcessor:
         windowed_calendar = self._extract_time_window(
             calendar, window_start, window_duration_days, verbose
         )
+
+        # Normalize target names up front (before the roll sweep). The roll
+        # sweep keys its results by target name, so any +/space -> _ rename
+        # must happen before the sweep or the renamed targets lose their
+        # swept roll and fall back to the sun-derived value.
+        if getattr(self, "fix_bad_data", False):
+            self._normalize_target_names(windowed_calendar, verbose)
 
         # Capture windowed calendar statistics (not original full calendar)
         self._analyze_original_calendar(
@@ -2559,6 +2567,78 @@ class ScheduleProcessor:
 
         return sequence
 
+    @staticmethod
+    def _clean_name(name: str) -> str:
+        """Replace every :data:`BAD_NAME_SYMBOLS` character in *name*."""
+        for bad, good in BAD_NAME_SYMBOLS.items():
+            name = name.replace(bad, good)
+        return name
+
+    def _normalize_sequence_names(
+        self, sequence: ObservationSequence, visit_id: Any = None
+    ) -> bool:
+        """Replace invalid symbols in a sequence's target name fields.
+
+        Substitutes every :data:`BAD_NAME_SYMBOLS` character (e.g. ``+`` and
+        space -> ``_``) in the sequence's ``target`` attribute and any
+        ``Target``/``TargetID`` payload tags. Returns ``True`` if anything
+        changed. Idempotent: re-running on an already-clean sequence is a
+        no-op. This runs up front (before the roll sweep) so the swept rolls,
+        which are keyed by target name, are not orphaned by a later rename.
+        """
+        prefix = self._seq_prefix(visit_id, sequence)
+        changed = False
+
+        # The sequence's target name attribute.
+        if sequence.target:
+            fixed = self._clean_name(sequence.target)
+            if fixed != sequence.target:
+                self._print(
+                    f"{prefix} | BAD DATA: Target "
+                    f"'{sequence.target}' -> '{fixed}'"
+                )
+                sequence.target = fixed
+                changed = True
+
+        # Any Target/TargetID payload tags.
+        for section_elem in sequence.payload_params.values():
+            if not isinstance(section_elem, ET.Element):
+                continue
+            for elem in section_elem.iter():
+                tag = elem.tag.rsplit("}", 1)[-1]
+                if tag not in ("Target", "TargetID") or not elem.text:
+                    continue
+                fixed = self._clean_name(elem.text)
+                if fixed != elem.text:
+                    self._print(
+                        f"{prefix} | BAD DATA: {tag} "
+                        f"'{elem.text}' -> '{fixed}'"
+                    )
+                    elem.text = fixed
+                    changed = True
+        return changed
+
+    def _normalize_target_names(
+        self, calendar: ScienceCalendar, verbose: bool = False
+    ) -> None:
+        """Normalize target name fields across the whole calendar up front.
+
+        Runs immediately after windowing -- before the roll sweep -- so the
+        target names the roll sweep keys on match the names present when the
+        precomputed rolls are applied. Without this, a later ``+``/space ->
+        ``_`` rename would orphan a target's swept roll, dropping it back to
+        the sun-derived fallback.
+        """
+        n_changed = 0
+        for visit in calendar.visits:
+            for seq in visit.sequences:
+                if self._normalize_sequence_names(seq, visit_id=visit.id):
+                    n_changed += 1
+        if verbose and n_changed:
+            self._print(
+                f"Normalized invalid symbols in {n_changed} target name(s)."
+            )
+
     def _fix_bad_data(
         self, sequence: ObservationSequence, visit_id: Any = None
     ) -> None:
@@ -2568,7 +2648,9 @@ class ScheduleProcessor:
 
         - ``Target``/``TargetID`` fields (the sequence's ``target`` attribute
           and any ``Target``/``TargetID`` payload tags) have each symbol in
-          ``BAD_NAME_SYMBOLS`` replaced by its safe substitute.
+          ``BAD_NAME_SYMBOLS`` replaced by its safe substitute (see
+          :meth:`_normalize_sequence_names`; normally already applied up front
+          by :meth:`_normalize_target_names`, so this is a safety net).
         - Every other field is scanned for NaN-like text; matches in tags not
           listed in ``NON_NUMERIC_TAGS`` are logged as warnings. Free-time
           observations are skipped here because their RA/Dec are expected to
@@ -2576,35 +2658,8 @@ class ScheduleProcessor:
         """
         prefix = self._seq_prefix(visit_id, sequence)
 
-        # 1) Replace invalid symbols in the sequence's target name.
-        if sequence.target:
-            fixed = sequence.target
-            for bad, good in BAD_NAME_SYMBOLS.items():
-                fixed = fixed.replace(bad, good)
-            if fixed != sequence.target:
-                self._print(
-                    f"{prefix} | BAD DATA: Target "
-                    f"'{sequence.target}' -> '{fixed}'"
-                )
-                sequence.target = fixed
-
-        # 2) Replace invalid symbols in any Target/TargetID payload tags.
-        for section_elem in sequence.payload_params.values():
-            if not isinstance(section_elem, ET.Element):
-                continue
-            for elem in section_elem.iter():
-                tag = elem.tag.rsplit("}", 1)[-1]
-                if tag not in ("Target", "TargetID") or not elem.text:
-                    continue
-                fixed = elem.text
-                for bad, good in BAD_NAME_SYMBOLS.items():
-                    fixed = fixed.replace(bad, good)
-                if fixed != elem.text:
-                    self._print(
-                        f"{prefix} | BAD DATA: {tag} "
-                        f"'{elem.text}' -> '{fixed}'"
-                    )
-                    elem.text = fixed
+        # 1+2) Replace invalid symbols in the target name fields.
+        self._normalize_sequence_names(sequence, visit_id=visit_id)
 
         # 3) Scan numeric fields for NaN-like values (report only). Free-time
         # observations legitimately carry NaN RA/Dec, so skip them.

--- a/src/shortschedule/scheduler.py
+++ b/src/shortschedule/scheduler.py
@@ -55,6 +55,31 @@ from .roll import apply_rolls_to_calendar, find_best_rolls_for_visit
 from .visda import VisdaData
 
 
+# Characters that are not allowed in target name fields (``Target`` /
+# ``TargetID``) because they break downstream filename and identifier
+# handling. Each bad symbol is mapped to its safe replacement and substituted
+# by the ``fix_bad_data`` pass.
+BAD_NAME_SYMBOLS = {
+    "+": "_",
+}
+
+# Tag names whose values are expected to be non-numeric (names, IDs,
+# timestamps, TLE lines). They are excluded from the NaN-like value scan run
+# by the ``fix_bad_data`` pass.
+NON_NUMERIC_TAGS = frozenset(
+    {
+        "Target",
+        "TargetID",
+        "ID",
+        "Start",
+        "Stop",
+        "TLE_Line1",
+        "TLE_Line2",
+        "Calendar_Status",
+    }
+)
+
+
 class ScheduleProcessor:
     """Main class for processing and adjusting science calendars with updated TLE.
 
@@ -98,6 +123,7 @@ class ScheduleProcessor:
         update_nirda_reset1_for_vitl: bool = True,
         vitl_settling_time: u.Quantity = 60.0 * u.s,
         convert_single_roi_to_predefined: bool = True,
+        fix_bad_data: bool = True,
         moon_min: Optional[float] = 20.0,
         sun_min: Optional[float] = 91.0,
         earthlimb_min: Optional[float] = 20.0,
@@ -191,6 +217,13 @@ class ScheduleProcessor:
             method (``StarRoiDetMethod == 1``) with the target RA/Dec written
             as the single predefined ROI (``numPredefinedStarRois == 1``,
             ``PredefinedStarRoiRa/RA1``, ``PredefinedStarRoiDec/Dec1``).
+        fix_bad_data : bool, optional
+            When True (default), each observation's target name fields
+            (``Target``/``TargetID``) have invalid symbols replaced per
+            ``BAD_NAME_SYMBOLS`` (e.g. ``+`` -> ``_``), and all other
+            (numeric) fields are scanned for NaN-like values, which are logged
+            as warnings. Free-time observations are exempt from the NaN scan
+            because their RA/Dec are expected to be NaN.
         moon_min, sun_min, earthlimb_min, mars_min, jupiter_min : float, optional
             Minimum angular separations (degrees) for visibility constraints.
         earthlimb_day_min : float, optional
@@ -364,6 +397,11 @@ class ScheduleProcessor:
         # converted to the predefined-ROI method (StarRoiDetMethod == 1) with
         # the target RA/Dec supplied as the single predefined ROI.
         self.convert_single_roi_to_predefined = convert_single_roi_to_predefined
+
+        # Bad-data fixes: when enabled, target name fields have invalid
+        # symbols (see BAD_NAME_SYMBOLS) replaced, and all other fields are
+        # scanned for NaN-like values (reported as warnings).
+        self.fix_bad_data = fix_bad_data
 
         # Enhanced gap tracking with before/after comparison
         self.gap_report = {
@@ -2507,7 +2545,80 @@ class ScheduleProcessor:
         if getattr(self, "convert_single_roi_to_predefined", False):
             self._convert_single_roi_to_predefined(sequence, visit_id=visit_id)
 
+        # Fix bad data (invalid name symbols + NaN-like value reporting).
+        if getattr(self, "fix_bad_data", False):
+            self._fix_bad_data(sequence, visit_id=visit_id)
+
         return sequence
+
+    def _fix_bad_data(
+        self, sequence: ObservationSequence, visit_id: Any = None
+    ) -> None:
+        """Replace invalid name symbols and report NaN-like field values.
+
+        Mirrors the CalendarCleaner ``Fix_Bad_Data`` step:
+
+        - ``Target``/``TargetID`` fields (the sequence's ``target`` attribute
+          and any ``Target``/``TargetID`` payload tags) have each symbol in
+          ``BAD_NAME_SYMBOLS`` replaced by its safe substitute.
+        - Every other field is scanned for NaN-like text; matches in tags not
+          listed in ``NON_NUMERIC_TAGS`` are logged as warnings. Free-time
+          observations are skipped here because their RA/Dec are expected to
+          be NaN.
+        """
+        prefix = self._seq_prefix(visit_id, sequence)
+
+        # 1) Replace invalid symbols in the sequence's target name.
+        if sequence.target:
+            fixed = sequence.target
+            for bad, good in BAD_NAME_SYMBOLS.items():
+                fixed = fixed.replace(bad, good)
+            if fixed != sequence.target:
+                self._print(
+                    f"{prefix} | BAD DATA: Target "
+                    f"'{sequence.target}' -> '{fixed}'"
+                )
+                sequence.target = fixed
+
+        # 2) Replace invalid symbols in any Target/TargetID payload tags.
+        for section_elem in sequence.payload_params.values():
+            if not isinstance(section_elem, ET.Element):
+                continue
+            for elem in section_elem.iter():
+                tag = elem.tag.rsplit("}", 1)[-1]
+                if tag not in ("Target", "TargetID") or not elem.text:
+                    continue
+                fixed = elem.text
+                for bad, good in BAD_NAME_SYMBOLS.items():
+                    fixed = fixed.replace(bad, good)
+                if fixed != elem.text:
+                    self._print(
+                        f"{prefix} | BAD DATA: {tag} "
+                        f"'{elem.text}' -> '{fixed}'"
+                    )
+                    elem.text = fixed
+
+        # 3) Scan numeric fields for NaN-like values (report only). Free-time
+        # observations legitimately carry NaN RA/Dec, so skip them.
+        if (sequence.target or "").strip().lower() in (
+            "free time",
+            "freetime",
+            "free_time",
+            "free-time",
+        ):
+            return
+        for section, section_elem in sequence.payload_params.items():
+            if not isinstance(section_elem, ET.Element):
+                continue
+            for elem in section_elem.iter():
+                tag = elem.tag.rsplit("}", 1)[-1]
+                if tag in NON_NUMERIC_TAGS or not elem.text:
+                    continue
+                if elem.text.strip().lower() == "nan":
+                    self._print(
+                        f"WARNING: {prefix} | BAD DATA: {section}/{tag} "
+                        f"has NaN-like value '{elem.text.strip()}'"
+                    )
 
     def _convert_single_roi_to_predefined(
         self, sequence: ObservationSequence, visit_id: Any = None

--- a/src/shortschedule/scheduler.py
+++ b/src/shortschedule/scheduler.py
@@ -89,8 +89,8 @@ class ScheduleProcessor:
         vda_post_sequence_overhead: u.Quantity | None = None,
         nirda_pre_sequence_overhead: u.Quantity | None = None,
         nirda_post_sequence_overhead: u.Quantity | None = None,
-        override_nirda_parameters: Optional[Dict[int, List[str]]] = None,
-        override_visda_parameters: Optional[Dict[int, List[str]]] = None,
+        override_nirda_parameters: Optional[Dict[int, Dict[str, Any]]] = None,
+        override_visda_parameters: Optional[Dict[int, Dict[str, Any]]] = None,
         max_file_size_uncompressed: u.Quantity = 830.0 * 1000 * 1000 * u.byte,
         max_file_size_compressed: u.Quantity = 255.0 * 1000 * 1000 * u.byte,
         update_nirda_reset1_for_vitl: bool = True,
@@ -131,23 +131,25 @@ class ScheduleProcessor:
             NIRDA post-sequence overhead (default is None which will use the overhead defaults).
         override_nirda_parameters : dict, optional
             Per-priority NIRDA payload overrides applied during the
-            payload-update step. Maps an observation priority to a list of
-            ``NirdaData`` field names whose values should be replaced by the
-            ``NirdaData`` defaults instead of being read from the
-            observation. For example:
-                ``{0: ['drop_frames_1', 'drop_frames_3']}``
-                    means: for every priority-0 observation, use the default-class
-                    values for ``drop_frames_1`` and ``drop_frames_3``
-                    (and write them back onto the observation) before
-                    recomputing SC_Integrations.
-            Field names are ``NirdaData`` attribute names; the corresponding XML
-            tags are updated automatically.
-            Defaults to no overrides.
+            payload-update step. Maps an observation priority to a mapping of
+            ``NirdaData`` field names to the values to force; a value of
+            ``None`` means "use the ``NirdaData`` default". For example:
+                ``{0: {'drop_frames_1': 2, 'drop_frames_3': None},
+                   1: {'reset_frames_1': 30}}``
+                    means: for every priority-0 observation set
+                    ``drop_frames_1`` to 2 and ``drop_frames_3`` to the class
+                    default; for priority 1 set ``reset_frames_1`` to 30. The
+                    overridden values are written back onto the observation
+                    before recomputing SC_Integrations.
+            Field names are ``NirdaData`` attribute names; the corresponding
+            XML tags are updated automatically. An iterable of field names is
+            also accepted (treated as all-default, e.g.
+            ``{0: ['drop_frames_1']}``). Defaults to no overrides.
         override_visda_parameters : dict, optional
             Per-priority VISDA payload overrides, structured identically to
-            ``override_nirda_parameters`` but using ``VisdaData`` field
-            names (e.g. ``frames_per_coadd``, ``exposure_time_s``).
-            Defaults to no overrides.
+            ``override_nirda_parameters`` but using ``VisdaData`` field names
+            (e.g. ``{0: {'frames_per_coadd': 5}}``). Defaults to no
+            overrides.
         max_file_size_uncompressed : Quantity[byte], optional
             Maximum allowed *uncompressed* data volume per detector per
             sequence. A warning is raised during the payload-update step if a
@@ -306,11 +308,13 @@ class ScheduleProcessor:
         )
 
         # Per-priority payload overrides applied during the payload-update
-        # step. Structure: { priority: [data_class_field_name, ...] }
-        self._override_nirda_parameters: Dict[int, List[str]] = (
+        # step. Structure: { priority: {field_name: value-or-None} }, where a
+        # None value means "use the data-class default". An iterable of field
+        # names is also accepted (treated as all-default).
+        self._override_nirda_parameters: Dict[int, Any] = (
             override_nirda_parameters or {}
         )
-        self._override_visda_parameters: Dict[int, List[str]] = (
+        self._override_visda_parameters: Dict[int, Any] = (
             override_visda_parameters or {}
         )
 
@@ -2220,10 +2224,14 @@ class ScheduleProcessor:
         taken from the data class itself (``PAYLOAD_SECTION``,
         ``CONFIG_SPEC``, ``REQUIRED_CONFIG_FIELDS``). For each config field
         the value is read from the observation's payload XML and converted
-        to the data-class field. Fields named in *override_fields* are
-        instead taken from a default ``data_cls()`` instance (via
-        ``get_config``) and queued to be written back to the observation so
-        the calendar reflects the override.
+        to the data-class field. Fields in *override_fields* are instead
+        forced and queued to be written back to the observation so the
+        calendar reflects the override.
+
+        *override_fields* may be either a mapping ``{field_name: value}``
+        (a non-``None`` value is used directly; ``None`` means "use the
+        ``data_cls`` default") or an iterable of field names (treated as
+        "use the default" for each).
 
         Returns
         -------
@@ -2236,7 +2244,14 @@ class ScheduleProcessor:
         spec = data_cls.CONFIG_SPEC
         required_fields = data_cls.REQUIRED_CONFIG_FIELDS
 
-        override_fields = set(override_fields or ())
+        # Normalize override_fields to a {field: value-or-None} mapping. A
+        # dict supplies explicit values (None -> class default); an iterable
+        # of names means "use the default" for each.
+        if isinstance(override_fields, dict):
+            overrides = dict(override_fields)
+        else:
+            overrides = {field: None for field in (override_fields or ())}
+
         default_config = data_cls().get_config()
         kwargs: Dict[str, Any] = dict(extra_kwargs or {})
         # Share the run logger so the data class's own warnings (zero frame
@@ -2246,8 +2261,10 @@ class ScheduleProcessor:
         missing: List[str] = []
 
         for field, (tag, from_xml, to_xml) in spec.items():
-            if field in override_fields:
-                value = default_config[field]
+            if field in overrides:
+                # None -> class default; otherwise use the supplied value.
+                ov = overrides[field]
+                value = default_config[field] if ov is None else ov
                 kwargs[field] = value
                 writeback[tag] = to_xml(value)
                 continue

--- a/src/shortschedule/scheduler.py
+++ b/src/shortschedule/scheduler.py
@@ -17,6 +17,7 @@ import copy
 import logging
 import uuid
 import warnings
+import xml.etree.ElementTree as ET
 from collections import defaultdict
 from copy import deepcopy
 from datetime import datetime, timedelta
@@ -91,6 +92,7 @@ class ScheduleProcessor:
         nirda_post_sequence_overhead: u.Quantity | None = None,
         override_nirda_parameters: Optional[Dict[int, Dict[str, Any]]] = None,
         override_visda_parameters: Optional[Dict[int, Dict[str, Any]]] = None,
+        override_payload_parameters: Optional[Dict[Any, Dict[str, Dict[str, Any]]]] = None,
         max_file_size_uncompressed: u.Quantity = 830.0 * 1000 * 1000 * u.byte,
         max_file_size_compressed: u.Quantity = 255.0 * 1000 * 1000 * u.byte,
         update_nirda_reset1_for_vitl: bool = True,
@@ -149,6 +151,19 @@ class ScheduleProcessor:
             Per-priority VISDA payload overrides, structured identically to
             ``override_nirda_parameters`` but using ``VisdaData`` field names
             (e.g. ``{0: {'frames_per_coadd': 5}}``). Defaults to no
+            overrides.
+        override_payload_parameters : dict, optional
+            General per-priority overrides written directly onto the payload
+            XML by tag name (the CalendarCleaner ``config.json`` format).
+            Structure: ``{priority: {section: {xml_tag: value}}}`` where
+            *section* is e.g. ``'AcquireInfCamImages'`` or
+            ``'AcquireVisCamScienceData'`` and *xml_tag* is a literal payload
+            tag (``ROI_StartX``, ``ROI_SizeX``, ``SC_Resets2``,
+            ``FramesPerCoadd``, ``RiceX`` ...). Tags missing from an
+            observation are created. Priority keys may be ints (``0``) or
+            ``'Priority_0'`` strings. These are applied *before* the
+            integration counts are recomputed, so size/coadd/reset changes
+            flow through. Free-time observations are skipped. Defaults to no
             overrides.
         max_file_size_uncompressed : Quantity[byte], optional
             Maximum allowed *uncompressed* data volume per detector per
@@ -316,6 +331,11 @@ class ScheduleProcessor:
         )
         self._override_visda_parameters: Dict[int, Any] = (
             override_visda_parameters or {}
+        )
+        # General per-priority XML-tag payload overrides (cleaner config.json
+        # format). Normalized to int priority keys.
+        self._override_payload_parameters: Dict[int, Any] = (
+            self._normalize_priority_keys(override_payload_parameters)
         )
 
         # Per-observation data-volume limits. A warning is raised during the
@@ -2330,12 +2350,114 @@ class ScheduleProcessor:
             self._print(f"Warning: {msg}")
             warnings.warn(msg, stacklevel=2)
 
+    @staticmethod
+    def _normalize_priority_keys(raw: Optional[Dict[Any, Any]]) -> Dict[int, Any]:
+        """Coerce override priority keys to ints (accepts 'Priority_0', '0')."""
+        out: Dict[int, Any] = {}
+        for key, value in (raw or {}).items():
+            if isinstance(key, bool):
+                # bool is an int subclass; reject to avoid surprises.
+                raise ValueError(f"Invalid priority key: {key!r}")
+            if isinstance(key, int):
+                priority = key
+            elif isinstance(key, str):
+                token = key.strip()
+                if token.lower().startswith("priority_"):
+                    token = token.split("_", 1)[1]
+                priority = int(token)
+            else:
+                raise ValueError(f"Invalid priority key: {key!r}")
+            out[priority] = value
+        return out
+
+    @staticmethod
+    def _format_payload_value(value: Any) -> str:
+        """Format a Python value as payload XML text (cleaner-compatible)."""
+        if isinstance(value, bool):
+            return "true" if value else "false"
+        if isinstance(value, float):
+            if value.is_integer():
+                return str(int(value))
+            return f"{value:.6f}".rstrip("0").rstrip(".")
+        return str(value)
+
+    def _set_override_element(
+        self,
+        parent: "ET.Element",
+        mapping: Dict[str, Any],
+        prefix: str,
+        path: str,
+    ) -> None:
+        """Recursively force *mapping* onto *parent*, creating missing tags.
+
+        Scalar values are written as element text; nested dicts create (or
+        descend into) child elements, supporting structures like
+        ``{'Boresight': {'PRI_CMD_DIR': 9}}``.
+        """
+        for tag, value in mapping.items():
+            child = parent.find(tag)
+            if child is None:
+                child = ET.SubElement(parent, tag)
+            if isinstance(value, dict):
+                self._set_override_element(
+                    child, value, prefix, f"{path}/{tag}"
+                )
+            else:
+                old = child.text
+                child.text = self._format_payload_value(value)
+                self._print(
+                    f"{prefix} | PAYLOAD OVERRIDE: {path}/{tag} "
+                    f"'{old}' -> '{child.text}'"
+                )
+
+    def _apply_payload_overrides(
+        self, sequence: ObservationSequence, visit_id: Any = None
+    ) -> None:
+        """Force per-priority XML overrides onto a sequence.
+
+        Writes ``override_payload_parameters[priority][section][...]`` onto
+        the observation, creating any missing tag (or section). Values may be
+        nested dicts (e.g. ``Observational_Parameters -> Boresight ->
+        PRI_CMD_DIR``). The payload detector sections
+        (``AcquireInfCamImages`` / ``AcquireVisCamScienceData``) and an
+        ``Observational_Parameters`` override are all stored on
+        ``payload_params``; the writer merges the latter into the
+        Observational_Parameters block it builds. Free-time observations are
+        skipped. Runs before the integration recompute so size/coadd/reset
+        changes take effect.
+        """
+        overrides = getattr(self, "_override_payload_parameters", {}) or {}
+        if not overrides:
+            return
+        entry = overrides.get(sequence.priority)
+        if not entry:
+            return
+        if (sequence.target or "").strip().lower() in (
+            "free time",
+            "freetime",
+            "free_time",
+            "free-time",
+        ):
+            return
+
+        prefix = self._seq_prefix(visit_id, sequence)
+        for section, mapping in entry.items():
+            section_elem = sequence.payload_params.get(section)
+            if section_elem is None:
+                section_elem = ET.Element(section)
+                sequence.payload_params[section] = section_elem
+            self._set_override_element(section_elem, mapping, prefix, section)
+
     def _update_payload_parameters_sequence(
         self, sequence: ObservationSequence, visit_id: Any = None
     ) -> ObservationSequence:
         # Pass sequence.duration (TimeDelta) so both helpers receive the
         # correct type and the overhead subtraction uses a consistent unit.
         duration = sequence.duration
+
+        # General XML-tag payload overrides first, so subsequent integration
+        # recomputation sees the forced ROI/coadd/reset values.
+        self._apply_payload_overrides(sequence, visit_id=visit_id)
 
         # Per-priority parameter overrides (see process_calendar). Falls back
         # to no overrides when the attributes are unset (e.g. when a bare

--- a/src/shortschedule/scheduler.py
+++ b/src/shortschedule/scheduler.py
@@ -29,6 +29,22 @@ from astropy.coordinates import get_body
 from astropy.time import Time, TimeDelta
 from pandoravisibility import Visibility
 
+try:
+    from tqdm.auto import tqdm
+except ImportError:  # pragma: no cover - tqdm is an optional
+    tqdm = None
+
+
+class _NullProgress:
+    """No-op stand-in for a tqdm bar (used when tqdm is unavailable)."""
+
+    def update(self, n: int = 1) -> None:
+        pass
+
+    def close(self) -> None:
+        pass
+
+
 from .models import ObservationSequence, ScienceCalendar, Visit
 from .nirda import NirdaData
 from .overhead import OverheadTiming
@@ -760,7 +776,11 @@ class ScheduleProcessor:
         # Only run the sweep when star-tracker constraints are active;
         # boresight-only constraints are roll-independent.
         if self._roll_sweep_enabled:
-            for visit in working_calendar.visits:
+            for visit in self._progress(
+                working_calendar.visits,
+                desc="Roll sweep",
+                total=len(working_calendar.visits),
+            ):
                 visit_rolls = find_best_rolls_for_visit(
                     self.visibility,
                     visit,
@@ -780,6 +800,10 @@ class ScheduleProcessor:
         i = 0
         last_stop = deepcopy(start_time)
 
+        vis_bar = self._progress_bar(
+            sum(len(v.sequences) for v in working_calendar.visits),
+            desc="Computing visibility",
+        )
         for visit in working_calendar.visits:
             visit_rolls = self._computed_target_rolls.get(visit.id, {})
 
@@ -824,6 +848,8 @@ class ScheduleProcessor:
 
                 i += len(vis)
                 last_stop = seq.stop_time
+                vis_bar.update(1)
+        vis_bar.close()
 
         # Fill remaining time after last sequence
         if i < total_minutes:
@@ -987,7 +1013,11 @@ class ScheduleProcessor:
                 all_sequences.append((visit.id, seq))
         all_sequences.sort(key=lambda x: x[1].start_time)
 
-        for idx, (visit_id, seq) in enumerate(all_sequences):
+        for idx, (visit_id, seq) in self._progress(
+            list(enumerate(all_sequences)),
+            desc="Trimming non-visible heads",
+            total=len(all_sequences),
+        ):
             n_mins = int(np.rint(seq.duration.sec / 60.0))
             if n_mins <= 0:
                 continue
@@ -1128,7 +1158,11 @@ class ScheduleProcessor:
                 all_sequences.append((visit.id, seq))
         all_sequences.sort(key=lambda x: x[1].start_time)
 
-        for idx, (visit_id, seq) in enumerate(all_sequences):
+        for idx, (visit_id, seq) in self._progress(
+            list(enumerate(all_sequences)),
+            desc="Trimming non-visible tails",
+            total=len(all_sequences),
+        ):
             n_mins = int(np.rint(seq.duration.sec / 60.0))
             if n_mins <= 0:
                 continue
@@ -1382,7 +1416,11 @@ class ScheduleProcessor:
                 all_sequences.append((visit.id, seq))
         all_sequences.sort(key=lambda x: x[1].start_time)
 
-        for idx, (visit_id, seq) in enumerate(all_sequences):
+        for idx, (visit_id, seq) in self._progress(
+            list(enumerate(all_sequences)),
+            desc="Trimming to longest visible block",
+            total=len(all_sequences),
+        ):
             analysis = self._analyze_mid_sequence_visibility(visit_id, seq)
             if analysis is None:
                 continue
@@ -1721,7 +1759,11 @@ class ScheduleProcessor:
                 all_sequences.append((visit.id, seq))
         all_sequences.sort(key=lambda x: x[1].start_time)
 
-        for idx in range(len(all_sequences) - 1):
+        for idx in self._progress(
+            range(len(all_sequences) - 1),
+            desc="Force-filling gaps",
+            total=len(all_sequences) - 1,
+        ):
             prev_vid, prev_seq = all_sequences[idx]
             next_vid, next_seq = all_sequences[idx + 1]
 
@@ -1894,7 +1936,9 @@ class ScheduleProcessor:
             return assignments[idx]["ra"], assignments[idx]["dec"]
 
         # Process each visibility gap
-        for gap_start_idx, gap_end_idx in false_idx:
+        for gap_start_idx, gap_end_idx in self._progress(
+            false_idx, desc="Fixing visibility gaps", total=gaps_total
+        ):
             # Get times for this gap
             gap_times = []
             for x in range(0, gap_end_idx - gap_start_idx):
@@ -2507,6 +2551,10 @@ class ScheduleProcessor:
         """
         issues = []
 
+        vis_bar = self._progress_bar(
+            sum(len(v.sequences) for v in calendar.visits),
+            desc="Validating visibility",
+        )
         for visit in calendar.visits:
             visit_rolls = self._computed_target_rolls.get(visit.id, {})
             for seq in visit.sequences:
@@ -2767,6 +2815,9 @@ class ScheduleProcessor:
                     if report_issues:
                         self._print(message)
 
+                vis_bar.update(1)
+        vis_bar.close()
+
         return issues
 
     def validate_target_names(
@@ -2926,6 +2977,29 @@ class ScheduleProcessor:
         except Exception:
             start = str(getattr(seq, "start_time", "?"))
         return f"{start}-{seq.target}-{visit_id}-{seq.id}"
+
+    def _progress(self, iterable, desc: str, total: Optional[int] = None):
+        """Wraps iterables in a tqdm progress bar when available.
+
+        Falls back to the plain iterable if ``tqdm`` is not installed. The
+        bar auto-disables on non-interactive streams (``disable=None``), so
+        it shows during real runs but stays silent under pytest/CI.
+        """
+        if tqdm is None:
+            return iterable
+        return tqdm(
+            iterable, desc=desc, total=total, disable=None, leave=False
+        )
+
+    def _progress_bar(self, total: int, desc: str):
+        """Return a manually-updated progress bar (or a no-op fallback).
+
+        Use when a single bar must span a nested loop: call ``.update()``
+        per item and ``.close()`` when done.
+        """
+        if tqdm is None:
+            return _NullProgress()
+        return tqdm(total=total, desc=desc, disable=None, leave=False)
 
     def _initialize_gap_report(self) -> None:
         """Initialize/reset the gap report structure."""

--- a/src/shortschedule/scheduler.py
+++ b/src/shortschedule/scheduler.py
@@ -2141,15 +2141,13 @@ class ScheduleProcessor:
         sequence = self._update_VDA_integrations(
             sequence,
             duration,
-            pre_sequence_overhead=self.overhead.visda_pre_overhead_time,
-            post_sequence_overhead=self.overhead.visda_post_overhead_time,
+            overhead=self.overhead,
             override_fields=visda_fields,
         )
         sequence = self._update_NIRDA_integrations(
             sequence,
             duration,
-            pre_sequence_overhead=self.overhead.nirda_pre_overhead_time,
-            post_sequence_overhead=self.overhead.nirda_post_overhead_time,
+            overhead=self.overhead,
             override_fields=nirda_fields,
         )
 
@@ -2159,8 +2157,7 @@ class ScheduleProcessor:
         self,
         sequence: ObservationSequence,
         duration: TimeDelta,
-        pre_sequence_overhead: TimeDelta = 260 * u.s,
-        post_sequence_overhead: TimeDelta = 102 * u.s,
+        overhead: Optional[OverheadTiming] = None,
         override_fields: Any = (),
     ) -> ObservationSequence:
         """Set NumTotalFramesRequested using a ``VisdaData`` model.
@@ -2169,8 +2166,19 @@ class ScheduleProcessor:
         ``AcquireVisCamScienceData`` payload (or, for any field listed in
         *override_fields*, from the ``VisdaData`` defaults), and the frame
         count that fits the sequence duration -- net of the pre/post
-        overheads -- is computed by ``VisdaData.solve_integrations``.
+        overheads in *overhead* -- is computed by
+        ``VisdaData.solve_integrations``.
+
+        Parameters
+        ----------
+        overhead : OverheadTiming, optional
+            Overhead timings to apply. Defaults to ``self.overhead`` (built
+            once at construction); a bare ``OverheadTiming`` is used only if
+            the processor has none.
         """
+        if overhead is None:
+            overhead = getattr(self, "overhead", None) or OverheadTiming()
+
         # Detector read time is not represented in the payload; the existing
         # scheduling math treats a frame as taking exactly the exposure time.
         visda, info = self._build_payload_data(
@@ -2192,10 +2200,6 @@ class ScheduleProcessor:
                 "AcquireVisCamScienceData", tag, text
             )
 
-        overhead = OverheadTiming(
-            visda_pre_overhead_time=pre_sequence_overhead.to(u.s),
-            visda_post_overhead_time=post_sequence_overhead.to(u.s),
-        )
         frames, data, data_compressed = visda.solve_integrations(
             duration.to(u.s), overhead
         )
@@ -2219,8 +2223,7 @@ class ScheduleProcessor:
         self,
         sequence: ObservationSequence,
         duration: TimeDelta,
-        pre_sequence_overhead: TimeDelta = 258 * u.s,
-        post_sequence_overhead: TimeDelta = 102 * u.s,
+        overhead: Optional[OverheadTiming] = None,
         override_fields: Any = (),
     ) -> ObservationSequence:
         """Set SC_Integrations using a ``NirdaData`` model.
@@ -2229,9 +2232,19 @@ class ScheduleProcessor:
         ``AcquireInfCamImages`` payload (or, for any field listed in
         *override_fields*, from the ``NirdaData`` defaults), and the number
         of integrations that fit the sequence duration -- net of the
-        pre/post overheads -- is computed by
+        pre/post overheads in *overhead* -- is computed by
         ``NirdaData.solve_integrations``.
+
+        Parameters
+        ----------
+        overhead : OverheadTiming, optional
+            Overhead timings to apply. Defaults to ``self.overhead`` (built
+            once at construction); a bare ``OverheadTiming`` is used only if
+            the processor has none.
         """
+        if overhead is None:
+            overhead = getattr(self, "overhead", None) or OverheadTiming()
+
         nirda, info = self._build_payload_data(
             sequence,
             override_fields,
@@ -2253,10 +2266,6 @@ class ScheduleProcessor:
         for tag, text in info.items():
             sequence.set_payload_parameter("AcquireInfCamImages", tag, text)
 
-        overhead = OverheadTiming(
-            nirda_pre_overhead_time=pre_sequence_overhead.to(u.s),
-            nirda_post_overhead_time=post_sequence_overhead.to(u.s),
-        )
         integrations, data, data_compressed = nirda.solve_integrations(
             duration.to(u.s), overhead
         )

--- a/src/shortschedule/scheduler.py
+++ b/src/shortschedule/scheduler.py
@@ -97,6 +97,7 @@ class ScheduleProcessor:
         max_file_size_compressed: u.Quantity = 255.0 * 1000 * 1000 * u.byte,
         update_nirda_reset1_for_vitl: bool = True,
         vitl_settling_time: u.Quantity = 60.0 * u.s,
+        convert_single_roi_to_predefined: bool = True,
         moon_min: Optional[float] = 20.0,
         sun_min: Optional[float] = 91.0,
         earthlimb_min: Optional[float] = 20.0,
@@ -183,6 +184,13 @@ class ScheduleProcessor:
         vitl_settling_time : Quantity[second], optional
             Minimum VITL detector settling time used when
             ``update_nirda_reset1_for_vitl`` is True. Defaults to 60 s.
+        convert_single_roi_to_predefined : bool, optional
+            When True (default), any observation whose VIS section requests a
+            single brightest-star auto-detect ROI (``MaxNumStarRois == 1`` and
+            ``StarRoiDetMethod == 2``) is converted to the predefined-ROI
+            method (``StarRoiDetMethod == 1``) with the target RA/Dec written
+            as the single predefined ROI (``numPredefinedStarRois == 1``,
+            ``PredefinedStarRoiRa/RA1``, ``PredefinedStarRoiDec/Dec1``).
         moon_min, sun_min, earthlimb_min, mars_min, jupiter_min : float, optional
             Minimum angular separations (degrees) for visibility constraints.
         earthlimb_day_min : float, optional
@@ -349,6 +357,13 @@ class ScheduleProcessor:
         # integration count is computed.
         self.update_nirda_reset1_for_vitl = update_nirda_reset1_for_vitl
         self.vitl_settling_time = vitl_settling_time
+
+        # Single-ROI conversion: when enabled, any observation whose VIS
+        # section requests exactly one star ROI via the brightest-star
+        # auto-detect method (MaxNumStarRois == 1, StarRoiDetMethod == 2) is
+        # converted to the predefined-ROI method (StarRoiDetMethod == 1) with
+        # the target RA/Dec supplied as the single predefined ROI.
+        self.convert_single_roi_to_predefined = convert_single_roi_to_predefined
 
         # Enhanced gap tracking with before/after comparison
         self.gap_report = {
@@ -2484,7 +2499,123 @@ class ScheduleProcessor:
             visit_id=visit_id,
         )
 
+        # Convert single-ROI auto-detect observations to the predefined-ROI
+        # method. Runs after the overrides above so a forced MaxNumStarRois of
+        # 1 is taken into account; the conversion does not change timing or
+        # data volume, so its position relative to the integration recompute
+        # is immaterial.
+        if getattr(self, "convert_single_roi_to_predefined", False):
+            self._convert_single_roi_to_predefined(sequence, visit_id=visit_id)
+
         return sequence
+
+    def _convert_single_roi_to_predefined(
+        self, sequence: ObservationSequence, visit_id: Any = None
+    ) -> bool:
+        """Convert a single-ROI auto-detect VIS section to predefined-ROI.
+
+        Mirrors the CalendarCleaner ``Fix_Single_ROI_Det`` step: when the
+        ``AcquireVisCamScienceData`` section requests exactly one star ROI via
+        the brightest-star auto-detect method (``MaxNumStarRois == 1`` and
+        ``StarRoiDetMethod == 2``), switch it to the predefined-ROI method
+        (``StarRoiDetMethod == 1``) and supply the target RA/Dec as the single
+        predefined ROI.
+
+        The target RA/Dec is resolved verbatim, preferring the VIS section's
+        ``TargetRA``/``TargetDEC``, then the sequence's ``ra``/``dec``. The
+        conversion is idempotent: a section already carrying ``RA1``/``Dec1``
+        predefined children is left untouched. Returns True if a conversion
+        was made.
+        """
+        if (sequence.target or "").strip().lower() in (
+            "free time",
+            "freetime",
+            "free_time",
+            "free-time",
+        ):
+            return False
+
+        vis_section = sequence.payload_params.get("AcquireVisCamScienceData")
+        if vis_section is None:
+            return False
+
+        def _to_int(elem):
+            if elem is None or elem.text is None:
+                return None
+            try:
+                return int(float(elem.text))
+            except (ValueError, TypeError):
+                return None
+
+        max_rois = _to_int(vis_section.find("MaxNumStarRois"))
+        det_method = _to_int(vis_section.find("StarRoiDetMethod"))
+        if max_rois != 1 or det_method != 2:
+            return False
+
+        # Idempotency: only skip when an actual predefined ROI (RA1/Dec1) is
+        # already present, not a bare placeholder parent.
+        ra_parent = vis_section.find("PredefinedStarRoiRa")
+        dec_parent = vis_section.find("PredefinedStarRoiDec")
+        has_ra1 = ra_parent is not None and ra_parent.find("RA1") is not None
+        has_dec1 = dec_parent is not None and dec_parent.find("Dec1") is not None
+        if has_ra1 and has_dec1:
+            return False
+
+        # Resolve the target RA/Dec verbatim: prefer the VIS-section values,
+        # then fall back to the sequence's own coordinates.
+        def _usable(value):
+            return (
+                value is not None
+                and str(value).strip() != ""
+                and str(value).strip().lower() != "nan"
+            )
+
+        ra_elem = vis_section.find("TargetRA")
+        dec_elem = vis_section.find("TargetDEC")
+        ra = ra_elem.text if ra_elem is not None else None
+        dec = dec_elem.text if dec_elem is not None else None
+        if not _usable(ra) and sequence.ra is not None:
+            ra = self._format_payload_value(sequence.ra)
+        if not _usable(dec) and sequence.dec is not None:
+            dec = self._format_payload_value(sequence.dec)
+
+        prefix = self._seq_prefix(visit_id, sequence)
+        if not _usable(ra) or not _usable(dec):
+            self._print(
+                f"WARNING: {prefix} | SINGLE-ROI: no usable target RA/Dec "
+                f"(RA={ra!r}, Dec={dec!r}); left unchanged."
+            )
+            return False
+
+        ra = str(ra).strip()
+        dec = str(dec).strip()
+
+        # Switch to predefined-ROI method with a single ROI.
+        det_elem = vis_section.find("StarRoiDetMethod")
+        det_elem.text = "1"
+
+        num_elem = vis_section.find("numPredefinedStarRois")
+        if num_elem is None:
+            num_elem = ET.SubElement(vis_section, "numPredefinedStarRois")
+        num_elem.text = "1"
+
+        if ra_parent is None:
+            ra_parent = ET.SubElement(vis_section, "PredefinedStarRoiRa")
+        for stale in list(ra_parent):
+            ra_parent.remove(stale)
+        ET.SubElement(ra_parent, "RA1").text = ra
+
+        if dec_parent is None:
+            dec_parent = ET.SubElement(vis_section, "PredefinedStarRoiDec")
+        for stale in list(dec_parent):
+            dec_parent.remove(stale)
+        ET.SubElement(dec_parent, "Dec1").text = dec
+
+        self._print(
+            f"{prefix} | SINGLE-ROI: StarRoiDetMethod 2 -> 1, "
+            f"numPredefinedStarRois=1, RA1={ra}, Dec1={dec}"
+        )
+        return True
 
     def _update_VDA_integrations(
         self,

--- a/src/shortschedule/scheduler.py
+++ b/src/shortschedule/scheduler.py
@@ -27,7 +27,10 @@ from astropy.time import Time, TimeDelta
 from pandoravisibility import Visibility
 
 from .models import ObservationSequence, ScienceCalendar, Visit
+from .nirda import NirdaData
+from .overhead import OverheadTiming
 from .roll import apply_rolls_to_calendar, find_best_rolls_for_visit
+from .visda import VisdaData
 
 
 class ScheduleProcessor:
@@ -61,10 +64,12 @@ class ScheduleProcessor:
         self,
         tle_line1: str,
         tle_line2: str,
-        vda_pre_sequence_overhead: u.Quantity = 260 * u.s,
-        vda_post_sequence_overhead: u.Quantity = 102 * u.s,
-        nirda_pre_sequence_overhead: u.Quantity = 258 * u.s,
-        nirda_post_sequence_overhead: u.Quantity = 102 * u.s,
+        vda_pre_sequence_overhead: u.Quantity | None = None,
+        vda_post_sequence_overhead: u.Quantity | None = None,
+        nirda_pre_sequence_overhead: u.Quantity | None = None,
+        nirda_post_sequence_overhead: u.Quantity | None = None,
+        override_nirda_parameters: Optional[Dict[int, List[str]]] = None,
+        override_visda_parameters: Optional[Dict[int, List[str]]] = None,
         moon_min: Optional[float] = 20.0,
         sun_min: Optional[float] = 91.0,
         earthlimb_min: Optional[float] = 20.0,
@@ -92,13 +97,32 @@ class ScheduleProcessor:
         tle_line1, tle_line2 : str
             TLE lines for satellite
         vda_pre_sequence_overhead : Quantity, optional
-            VDA pre-sequence overhead (default 260 s).
+            VDA pre-sequence overhead (default is None which will use the overhead defaults).
         vda_post_sequence_overhead : Quantity, optional
-            VDA post-sequence overhead (default 102 s).
+            VDA post-sequence overhead (default is None which will use the overhead defaults).
         nirda_pre_sequence_overhead : Quantity, optional
-            NIRDA pre-sequence overhead (default 258 s).
+            NIRDA pre-sequence overhead (default is None which will use the overhead defaults).
         nirda_post_sequence_overhead : Quantity, optional
-            NIRDA post-sequence overhead (default 102 s).
+            NIRDA post-sequence overhead (default is None which will use the overhead defaults).
+        override_nirda_parameters : dict, optional
+            Per-priority NIRDA payload overrides applied during the
+            payload-update step. Maps an observation priority to a list of
+            ``NirdaData`` field names whose values should be replaced by the
+            ``NirdaData`` defaults instead of being read from the
+            observation. For example:
+                ``{0: ['drop_frames_1', 'drop_frames_3']}``
+                    means: for every priority-0 observation, use the default-class
+                    values for ``drop_frames_1`` and ``drop_frames_3``
+                    (and write them back onto the observation) before
+                    recomputing SC_Integrations.
+            Field names are ``NirdaData`` attribute names; the corresponding XML
+            tags are updated automatically.
+            Defaults to no overrides.
+        override_visda_parameters : dict, optional
+            Per-priority VISDA payload overrides, structured identically to
+            ``override_nirda_parameters`` but using ``VisdaData`` field
+            names (e.g. ``frames_per_coadd``, ``exposure_time_s``).
+            Defaults to no overrides.
         moon_min, sun_min, earthlimb_min, mars_min, jupiter_min : float, optional
             Minimum angular separations (degrees) for visibility constraints.
         earthlimb_day_min : float, optional
@@ -201,8 +225,9 @@ class ScheduleProcessor:
         #   { visit_id: { target_name: roll_deg_or_None } }
         self._computed_target_rolls: Dict[str, Dict[str, Optional[float]]] = {}
 
-        # Payload overhead budgets — validate that each value carries time
-        # units so that downstream .to(u.s) / .to(u.us) calls succeed.
+        # Validate any explicitly supplied overheads carry time units so that
+        # downstream .to(u.s) / .to(u.us) calls succeed. ``None`` means "use
+        # the OverheadTiming default derived from the modelled MOC sequence".
         _overhead_params = {
             "vda_pre_sequence_overhead": vda_pre_sequence_overhead,
             "vda_post_sequence_overhead": vda_post_sequence_overhead,
@@ -210,9 +235,9 @@ class ScheduleProcessor:
             "nirda_post_sequence_overhead": nirda_post_sequence_overhead,
         }
         for _name, _val in _overhead_params.items():
-            if isinstance(_val, TimeDelta):
-                pass
-            elif isinstance(_val, u.Quantity):
+            if _val is None or isinstance(_val, TimeDelta):
+                continue
+            if isinstance(_val, u.Quantity):
                 try:
                     _val.to(u.s)
                 except u.UnitConversionError:
@@ -225,10 +250,26 @@ class ScheduleProcessor:
                     f"{_name} must be an astropy Quantity or TimeDelta "
                     f"with time units; got {type(_val).__name__!r}"
                 )
-        self.vda_pre_sequence_overhead = vda_pre_sequence_overhead
-        self.vda_post_sequence_overhead = vda_post_sequence_overhead
-        self.nirda_pre_sequence_overhead = nirda_pre_sequence_overhead
-        self.nirda_post_sequence_overhead = nirda_post_sequence_overhead
+
+        # Collect the overheads into a single OverheadTiming so the
+        # payload-update step can hand it straight to the NIRDA/VISDA data
+        # classes. Note OverheadTiming uses "visda" naming for the VDA fields
+        # and fills any None with its modelled default.
+        self.overhead = OverheadTiming(
+            visda_pre_overhead_time=vda_pre_sequence_overhead,
+            visda_post_overhead_time=vda_post_sequence_overhead,
+            nirda_pre_overhead_time=nirda_pre_sequence_overhead,
+            nirda_post_overhead_time=nirda_post_sequence_overhead,
+        )
+
+        # Per-priority payload overrides applied during the payload-update
+        # step. Structure: { priority: [data_class_field_name, ...] }
+        self._override_nirda_parameters: Dict[int, List[str]] = (
+            override_nirda_parameters or {}
+        )
+        self._override_visda_parameters: Dict[int, List[str]] = (
+            override_visda_parameters or {}
+        )
 
         # Enhanced gap tracking with before/after comparison
         self.gap_report = {
@@ -1962,6 +2003,62 @@ class ScheduleProcessor:
 
         return calendar
 
+    def _build_payload_data(
+        self,
+        sequence: ObservationSequence,
+        override_fields: Any,
+        data_cls: Any,
+        extra_kwargs: Optional[Dict[str, Any]] = None,
+    ):
+        """Build a NirdaData/VisdaData object from a sequence's payload.
+
+        The payload section, field<->XML mapping, and required fields are
+        taken from the data class itself (``PAYLOAD_SECTION``,
+        ``CONFIG_SPEC``, ``REQUIRED_CONFIG_FIELDS``). For each config field
+        the value is read from the observation's payload XML and converted
+        to the data-class field. Fields named in *override_fields* are
+        instead taken from a default ``data_cls()`` instance (via
+        ``get_config``) and queued to be written back to the observation so
+        the calendar reflects the override.
+
+        Returns
+        -------
+        (data_obj, writeback) on success, where ``writeback`` maps XML tags
+        to the string values that should be written back to the payload for
+        overridden fields.  Returns ``(None, missing_tags)`` if any required
+        field is absent (e.g. a sequence with no payload for this section).
+        """
+        section = data_cls.PAYLOAD_SECTION
+        spec = data_cls.CONFIG_SPEC
+        required_fields = data_cls.REQUIRED_CONFIG_FIELDS
+
+        override_fields = set(override_fields or ())
+        default_config = data_cls().get_config()
+        kwargs: Dict[str, Any] = dict(extra_kwargs or {})
+        writeback: Dict[str, str] = {}
+        missing: List[str] = []
+
+        for field, (tag, from_xml, to_xml) in spec.items():
+            if field in override_fields:
+                value = default_config[field]
+                kwargs[field] = value
+                writeback[tag] = to_xml(value)
+                continue
+
+            raw = sequence.get_payload_parameter(section, tag)
+            if raw is None or raw == "":
+                if field in required_fields:
+                    missing.append(tag)
+                continue
+            try:
+                kwargs[field] = from_xml(raw)
+            except (ValueError, TypeError):
+                missing.append(tag)
+
+        if missing:
+            return None, missing
+        return data_cls(**kwargs), writeback
+
     def _update_payload_parameters_sequence(
         self, sequence: ObservationSequence
     ) -> ObservationSequence:
@@ -1969,17 +2066,27 @@ class ScheduleProcessor:
         # correct type and the overhead subtraction uses a consistent unit.
         duration = sequence.duration
 
+        # Per-priority parameter overrides (see process_calendar). Falls back
+        # to no overrides when the attributes are unset (e.g. when a bare
+        # ScheduleProcessor is constructed in tests).
+        nirda_overrides = getattr(self, "_override_nirda_parameters", {}) or {}
+        visda_overrides = getattr(self, "_override_visda_parameters", {}) or {}
+        nirda_fields = nirda_overrides.get(sequence.priority, ())
+        visda_fields = visda_overrides.get(sequence.priority, ())
+
         sequence = self._update_VDA_integrations(
             sequence,
             duration,
-            pre_sequence_overhead=self.vda_pre_sequence_overhead,
-            post_sequence_overhead=self.vda_post_sequence_overhead,
+            pre_sequence_overhead=self.overhead.visda_pre_overhead_time,
+            post_sequence_overhead=self.overhead.visda_post_overhead_time,
+            override_fields=visda_fields,
         )
         sequence = self._update_NIRDA_integrations(
             sequence,
             duration,
-            pre_sequence_overhead=self.nirda_pre_sequence_overhead,
-            post_sequence_overhead=self.nirda_post_sequence_overhead,
+            pre_sequence_overhead=self.overhead.nirda_pre_overhead_time,
+            post_sequence_overhead=self.overhead.nirda_post_overhead_time,
+            override_fields=nirda_fields,
         )
 
         return sequence
@@ -1989,180 +2096,109 @@ class ScheduleProcessor:
         sequence: ObservationSequence,
         duration: TimeDelta,
         pre_sequence_overhead: TimeDelta = 260 * u.s,
-        post_sequence_overhead: TimeDelta = 120 * u.s,
+        post_sequence_overhead: TimeDelta = 102 * u.s,
+        override_fields: Any = (),
     ) -> ObservationSequence:
+        """Set NumTotalFramesRequested using a ``VisdaData`` model.
 
-        # Include VDA overheads at the start and end of the sequence using
-        # pre_sequence_overhead and post_sequence_overhead.
-
-        # Get parameters
-        exposure_time_str = sequence.get_payload_parameter(
-            "AcquireVisCamScienceData", "ExposureTime_us"
+        The VISDA detector configuration is built from the sequence's
+        ``AcquireVisCamScienceData`` payload (or, for any field listed in
+        *override_fields*, from the ``VisdaData`` defaults), and the frame
+        count that fits the sequence duration -- net of the pre/post
+        overheads -- is computed by ``VisdaData.solve_integrations``.
+        """
+        # Detector read time is not represented in the payload; the existing
+        # scheduling math treats a frame as taking exactly the exposure time.
+        visda, info = self._build_payload_data(
+            sequence,
+            override_fields,
+            VisdaData,
+            extra_kwargs={"read_time_per_frame_s": 0 * u.s},
         )
-        frames_per_coadd_str = sequence.get_payload_parameter(
-            "AcquireVisCamScienceData", "FramesPerCoadd"
+        if visda is None:
+            print(
+                f"Warning: Missing VDA parameters for sequence "
+                f"{sequence.id} {sequence.start_time}: {', '.join(info)}"
+            )
+            return sequence
+
+        # Write any overridden parameters back onto the observation.
+        for tag, text in info.items():
+            sequence.set_payload_parameter(
+                "AcquireVisCamScienceData", tag, text
+            )
+
+        overhead = OverheadTiming(
+            visda_pre_overhead_time=pre_sequence_overhead.to(u.s),
+            visda_post_overhead_time=post_sequence_overhead.to(u.s),
         )
+        frames, _, _ = visda.solve_integrations(duration.to(u.s), overhead)
 
-        if not exposure_time_str or not frames_per_coadd_str:
+        success = sequence.set_payload_parameter(
+            "AcquireVisCamScienceData",
+            "NumTotalFramesRequested",
+            str(int(frames)),
+        )
+        if not success:
             print(
-                f"Warning: Missing VDA parameters for sequence {sequence.id} {sequence.start_time}"
+                f"Warning: Failed to update NumTotalFramesRequested for "
+                f"sequence {sequence.id} {sequence.start_time}"
             )
-            return sequence
-
-        try:
-            # Convert to proper types - exposure time is always integer microseconds
-            exposure_time = int(exposure_time_str) * u.us
-            frames_per_coadd = int(frames_per_coadd_str)
-
-            # Convert duration to microseconds for calculation
-            duration_us = (
-                duration.to(u.us)
-                - pre_sequence_overhead.to(u.us)
-                - post_sequence_overhead.to(u.us)
-            )
-
-            # Guard: if overhead exceeds duration, no frames are possible
-            if duration_us.value <= 0:
-                sequence.set_payload_parameter(
-                    "AcquireVisCamScienceData",
-                    "NumTotalFramesRequested",
-                    "0",
-                )
-                return sequence
-
-            # Calculate maximum complete coadds that fit in duration
-            effective_exposure_time = exposure_time * frames_per_coadd
-            max_coadds = int(np.floor(duration_us / effective_exposure_time))
-
-            # Calculate total frames (must be multiple of FramesPerCoadd)
-            num_total_frames = max_coadds * frames_per_coadd
-
-            # Ensure at least one coadd if duration allows
-            if (
-                num_total_frames == 0
-                and duration_us >= effective_exposure_time
-            ):
-                num_total_frames = frames_per_coadd
-
-            # Set the parameter (convert to string)
-            success = sequence.set_payload_parameter(
-                "AcquireVisCamScienceData",
-                "NumTotalFramesRequested",
-                str(num_total_frames),
-            )
-
-            if not success:
-                print(
-                    f"Warning: Failed to update NumTotalFramesRequested for sequence {sequence.id} {sequence.start_time}"
-                )
-            return sequence
-
-        except (ValueError, TypeError, AttributeError) as e:
-            print(
-                f"Error updating VDA parameters for sequence {sequence.id} {sequence.start_time}: {e}"
-            )
-            return sequence
+        return sequence
 
     def _update_NIRDA_integrations(
         self,
         sequence: ObservationSequence,
         duration: TimeDelta,
         pre_sequence_overhead: TimeDelta = 258 * u.s,
-        post_sequence_overhead: TimeDelta = 120 * u.s,
+        post_sequence_overhead: TimeDelta = 102 * u.s,
+        override_fields: Any = (),
     ) -> ObservationSequence:
+        """Set SC_Integrations using a ``NirdaData`` model.
 
-        seq_identifier = (
-            f"{sequence.id} ({sequence.target} @ "
-            f"{sequence.start_time.datetime.strftime('%m/%d %H:%M')})"
+        The NIRDA detector configuration is built from the sequence's
+        ``AcquireInfCamImages`` payload (or, for any field listed in
+        *override_fields*, from the ``NirdaData`` defaults), and the number
+        of integrations that fit the sequence duration -- net of the
+        pre/post overheads -- is computed by
+        ``NirdaData.solve_integrations``.
+        """
+        nirda, info = self._build_payload_data(
+            sequence,
+            override_fields,
+            NirdaData,
         )
-
-        # Collect raw string values and guard against missing parameters
-        # *before* any int() conversion so that a sequence without NIRDA
-        # payload (e.g. a VDA-only sequence) returns cleanly instead of
-        # raising TypeError.
-        required_params = {
-            name: sequence.get_payload_parameter("AcquireInfCamImages", name)
-            for name in (
-                "ROI_SizeX",
-                "ROI_SizeY",
-                "SC_Resets1",
-                "SC_Resets2",
-                "SC_DropFrames1",
-                "SC_DropFrames2",
-                "SC_DropFrames3",
-                "SC_ReadFrames",
-                "SC_Groups",
+        if nirda is None:
+            seq_identifier = (
+                f"{sequence.id} ({sequence.target} @ "
+                f"{sequence.start_time.datetime.strftime('%m/%d %H:%M')})"
             )
-        }
-
-        missing_params = [
-            name for name, value in required_params.items() if value is None
-        ]
-
-        if missing_params:
             print(
                 f"Warning: Missing NIRDA parameters for sequence "
                 f"{seq_identifier}"
             )
-            print(f"Missing parameters: {', '.join(missing_params)}")
+            print(f"Missing parameters: {', '.join(info)}")
             return sequence
 
-        # All parameters are present; convert to int.
-        ROI_SizeX = int(required_params["ROI_SizeX"])
-        ROI_SizeY = int(required_params["ROI_SizeY"])
-        SC_Resets1 = int(required_params["SC_Resets1"])
-        SC_Resets2 = int(required_params["SC_Resets2"])
-        SC_DropFrames1 = int(required_params["SC_DropFrames1"])
-        SC_DropFrames2 = int(required_params["SC_DropFrames2"])
-        SC_DropFrames3 = int(required_params["SC_DropFrames3"])
-        SC_ReadFrames = int(required_params["SC_ReadFrames"])
-        SC_Groups = int(required_params["SC_Groups"])
+        # Write any overridden parameters back onto the observation.
+        for tag, text in info.items():
+            sequence.set_payload_parameter("AcquireInfCamImages", tag, text)
 
-        # per the payload users guide
-        frame_time = (ROI_SizeX + 12) * (ROI_SizeY + 2) * 1e-5 * u.s
-        NumFramesBase = (
-            SC_DropFrames1
-            + (SC_Groups - 1) * (SC_ReadFrames + SC_DropFrames2)
-            + SC_ReadFrames
-            + SC_DropFrames3
+        overhead = OverheadTiming(
+            nirda_pre_overhead_time=pre_sequence_overhead.to(u.s),
+            nirda_post_overhead_time=post_sequence_overhead.to(u.s),
         )
-        NumFramesFirst = NumFramesBase + SC_Resets1
-        NumFramesOther = NumFramesBase + SC_Resets2
-        first_integration_time = NumFramesFirst * frame_time
-        other_integration_time = NumFramesOther * frame_time
-
-        # Use the duration argument so callers can override the window
-        # (e.g. _update_payload_parameters_sequence passes sequence.duration).
-        duration_sequence_seconds = duration.to(u.s)
-
-        effective_duration_s = (
-            duration_sequence_seconds
-            - pre_sequence_overhead.to(u.s)
-            - post_sequence_overhead.to(u.s)
+        integrations, _, _ = nirda.solve_integrations(
+            duration.to(u.s), overhead
         )
-        # Guard: if overhead exceeds duration, no integrations are possible
-        SC_Integrations = 0
-        if (effective_duration_s.value > 0) and (
-            first_integration_time.to(u.s) <= effective_duration_s.to(u.s)
-        ):
-            # There is enough time to perform the initial integration
-            effective_duration_s -= first_integration_time.to(u.s)
-            SC_Integrations += 1
-
-            # ... and potentially additional integrations.
-            if effective_duration_s > other_integration_time.to(u.s):
-                SC_Integrations += int(
-                    np.floor(
-                        effective_duration_s / other_integration_time.to(u.s)
-                    )
-                )
 
         success = sequence.set_payload_parameter(
-            "AcquireInfCamImages", "SC_Integrations", str(SC_Integrations)
+            "AcquireInfCamImages", "SC_Integrations", str(int(integrations))
         )
         if not success:
             print(
-                f"Warning: Failed to update SC_Integrations for sequence {sequence.id} {sequence.start_time}"
+                f"Warning: Failed to update SC_Integrations for sequence "
+                f"{sequence.id} {sequence.start_time}"
             )
 
         return sequence
@@ -2998,19 +3034,21 @@ class ScheduleProcessor:
         """
         issues = []
 
-        # Compute effective overhead budget (max of VDA/NIRDA)
-        pre_oh_sec = max(
-            getattr(self, "vda_pre_sequence_overhead", 0 * u.s).to(u.s).value,
-            getattr(self, "nirda_pre_sequence_overhead", 0 * u.s)
-            .to(u.s)
-            .value,
-        )
-        post_oh_sec = max(
-            getattr(self, "vda_post_sequence_overhead", 0 * u.s).to(u.s).value,
-            getattr(self, "nirda_post_sequence_overhead", 0 * u.s)
-            .to(u.s)
-            .value,
-        )
+        # Compute effective overhead budget (max of VDA/NIRDA). A bare
+        # processor without an OverheadTiming falls back to zero overhead.
+        overhead = getattr(self, "overhead", None)
+        if overhead is None:
+            pre_oh_sec = 0.0
+            post_oh_sec = 0.0
+        else:
+            pre_oh_sec = max(
+                overhead.visda_pre_overhead_time.to(u.s).value,
+                overhead.nirda_pre_overhead_time.to(u.s).value,
+            )
+            post_oh_sec = max(
+                overhead.visda_post_overhead_time.to(u.s).value,
+                overhead.nirda_post_overhead_time.to(u.s).value,
+            )
         total_oh_sec = pre_oh_sec + post_oh_sec
 
         for visit in calendar.visits:

--- a/src/shortschedule/scheduler.py
+++ b/src/shortschedule/scheduler.py
@@ -20,7 +20,12 @@ import warnings
 import xml.etree.ElementTree as ET
 from collections import defaultdict
 from copy import deepcopy
-from datetime import datetime, timedelta
+from datetime import datetime, timedelta, timezone
+
+try:
+    from zoneinfo import ZoneInfo
+except ImportError:  # pragma: no cover - zoneinfo is stdlib on 3.9+
+    ZoneInfo = None
 from pathlib import Path
 from typing import Any, Dict, List, Optional, Tuple
 
@@ -2458,10 +2463,13 @@ class ScheduleProcessor:
             else:
                 old = child.text
                 child.text = self._format_payload_value(value)
-                self._print(
-                    f"{prefix} | PAYLOAD OVERRIDE: {path}/{tag} "
-                    f"'{old}' -> '{child.text}'"
-                )
+                # Only report when the value actually changed.
+                old_norm = old.strip() if old is not None else None
+                if old_norm != child.text:
+                    self._print(
+                        f"{prefix} | PAYLOAD OVERRIDE: {path}/{tag} "
+                        f"'{old}' -> '{child.text}'"
+                    )
 
     def _apply_payload_overrides(
         self, sequence: ObservationSequence, visit_id: Any = None
@@ -2780,9 +2788,11 @@ class ScheduleProcessor:
             sequence.set_payload_parameter(
                 "AcquireVisCamScienceData", tag, text
             )
-            self._print(
-                f"{prefix} | VISDA OVERRIDE: {tag} '{old}' -> '{text}'"
-            )
+            # Only report when the value actually changed.
+            if (old if old is None else str(old)) != text:
+                self._print(
+                    f"{prefix} | VISDA OVERRIDE: {tag} '{old}' -> '{text}'"
+                )
 
         old_frames = sequence.get_payload_parameter(
             "AcquireVisCamScienceData", "NumTotalFramesRequested"
@@ -2857,9 +2867,11 @@ class ScheduleProcessor:
         for tag, text in info.items():
             old = sequence.get_payload_parameter("AcquireInfCamImages", tag)
             sequence.set_payload_parameter("AcquireInfCamImages", tag, text)
-            self._print(
-                f"{prefix} | NIRDA OVERRIDE: {tag} '{old}' -> '{text}'"
-            )
+            # Only report when the value actually changed.
+            if (old if old is None else str(old)) != text:
+                self._print(
+                    f"{prefix} | NIRDA OVERRIDE: {tag} '{old}' -> '{text}'"
+                )
 
         # Optionally adjust reset_frames_1 to cover the VITL settling time
         # before computing integrations, and persist the new SC_Resets1.
@@ -3670,7 +3682,9 @@ class ScheduleProcessor:
             except Exception:
                 pass
 
-        fmt = logging.Formatter("%(asctime)s %(levelname)s %(message)s")
+        # No per-entry timestamps; the run start time is recorded once in the
+        # log file header instead (see below).
+        fmt = logging.Formatter("%(message)s")
 
         # Console handler: gated by verbose for INFO, always shows warnings.
         console = logging.StreamHandler()
@@ -3688,8 +3702,25 @@ class ScheduleProcessor:
             log_file = base.with_suffix(".log")
             errors_file = base.with_suffix(".errors.log")
 
+            # Write a header recording the run start time in UTC and US
+            # Eastern, so individual entries need not carry timestamps. The
+            # FileHandler below then appends to this file.
+            now_utc = datetime.now(timezone.utc)
+            utc_str = now_utc.strftime("%Y-%m-%d %H:%M:%S %Z")
+            if ZoneInfo is not None:
+                eastern = now_utc.astimezone(ZoneInfo("America/New_York"))
+                eastern_str = eastern.strftime("%Y-%m-%d %H:%M:%S %Z")
+            else:  # pragma: no cover - zoneinfo missing
+                eastern_str = "unavailable (zoneinfo not installed)"
+            with open(log_file, "w", encoding="utf-8") as handle:
+                handle.write("=" * 70 + "\n")
+                handle.write("Short-term scheduler run log\n")
+                handle.write(f"Run start (UTC):     {utc_str}\n")
+                handle.write(f"Run start (Eastern): {eastern_str}\n")
+                handle.write("=" * 70 + "\n\n")
+
             file_handler = logging.FileHandler(
-                log_file, mode="w", encoding="utf-8"
+                log_file, mode="a", encoding="utf-8"
             )
             file_handler.setLevel(logging.INFO)
             file_handler.setFormatter(fmt)

--- a/src/shortschedule/scheduler.py
+++ b/src/shortschedule/scheduler.py
@@ -14,9 +14,11 @@ are provided. The processor performs these high-level steps:
 
 # Standard library
 import copy
+import logging
 import uuid
 import warnings
 from copy import deepcopy
+from pathlib import Path
 from typing import Any, Dict, List, Optional, Tuple
 
 # Third-party
@@ -336,6 +338,7 @@ class ScheduleProcessor:
         window_start: Optional[Any] = None,
         window_duration_days: int = 21,
         merge_similar_observations: bool = False,
+        log_path: Optional[Any] = None,
         verbose: bool = False,
     ) -> ScienceCalendar:
         """Process a `ScienceCalendar` and return an updated calendar.
@@ -365,8 +368,16 @@ class ScheduleProcessor:
             share the same target and pointing are merged into a single
             longer sequence.
             Defaults to False.
+        log_path : str or pathlib.Path, optional
+            Base path for the run log files. The ".log" (everything) and
+            ".errors.log" (warnings/errors only, created lazily) files are
+            named after this path's stem. When omitted, the input calendar's
+            ``source_path`` is used; if that is unavailable, only console
+            logging is produced.
         verbose : bool, optional
-            Print diagnostics when True.
+            When True, INFO-level diagnostics are echoed to the console; the
+            ".log" file always captures them regardless. Warnings and
+            errors are shown on the console either way.
 
         Returns
         -------
@@ -374,13 +385,15 @@ class ScheduleProcessor:
             Processed calendar with updated sequences and metadata.
         """
 
+        # Configure logging for this run (console + per-calendar log files).
+        self._setup_run_logging(calendar, verbose, log_path)
+
         # Clear previous gap report
         self._initialize_gap_report()
 
-        if verbose:
-            print("Processing calendar with TLE:")
-            print(f"  Line 1: {self.tle_line1}")
-            print(f"  Line 2: {self.tle_line2}")
+        self._print("Processing calendar with TLE:")
+        self._print(f"  Line 1: {self.tle_line1}")
+        self._print(f"  Line 2: {self.tle_line2}")
 
         # Extract windowed calendar FIRST
         windowed_calendar = self._extract_time_window(
@@ -483,18 +496,18 @@ class ScheduleProcessor:
 
         # Print compact validation summary
         if validation_counts:
-            print(
+            self._print(
                 f"\n--- Validation: {calendar_status} "
                 f"({sum(validation_counts.values())} issues) ---"
             )
             for cat, cnt in validation_counts.items():
-                print(f"  {cat}: {cnt}")
-            print(
+                self._print(f"  {cat}: {cnt}")
+            self._print(
                 "Run print_validation_summary(calendar) "
                 "for actionable details.\n"
             )
         else:
-            print(f"\n--- Validation: {calendar_status} " f"(0 issues) ---\n")
+            self._print(f"\n--- Validation: {calendar_status} " f"(0 issues) ---\n")
 
         new_metadata = copy.deepcopy(processed_calendar.metadata)
         new_metadata.update(
@@ -536,15 +549,14 @@ class ScheduleProcessor:
         self.window_start = window_start
         self.window_end = window_end
 
-        if verbose:
-            print(f"Extracting window: {window_start} to {window_end}")
+        self._print(f"Extracting window: {window_start} to {window_end}")
 
         # Find sequences within window
         windowed_visits = []
         for visit in calendar.visits:
             # complain if there are empty visits
             if not visit.sequences:
-                print(f"Warning: Empty sequence list for visit {visit.id}")
+                self._print(f"Warning: Empty sequence list for visit {visit.id}")
             windowed_sequences = []
             for seq in visit.sequences:
                 seq_start = seq.start_time
@@ -598,17 +610,23 @@ class ScheduleProcessor:
         for visit_index, visit in enumerate(calendar.visits, start=1):
             new_visit_id = f"{visit_index:04d}"
             if visit.id != new_visit_id:
+                self._print(
+                    f"RENUMBER visit ID '{visit.id}' -> '{new_visit_id}'"
+                )
                 visit.id = new_visit_id
                 changed += 1
 
             for seq_index, seq in enumerate(visit.sequences, start=1):
                 new_seq_id = f"{seq_index:03d}"
                 if seq.id != new_seq_id:
+                    self._print(
+                        f"{self._seq_prefix(visit.id, seq)} | RENUMBER "
+                        f"observation ID '{seq.id}' -> '{new_seq_id}'"
+                    )
                     seq.id = new_seq_id
                     changed += 1
 
-        if verbose:
-            print(f"Renumbered IDs: {changed} identifier(s) updated.")
+        self._print(f"Renumbered IDs: {changed} identifier(s) updated.")
 
         return calendar
 
@@ -657,13 +675,12 @@ class ScheduleProcessor:
                 if merged_sequences and self._can_merge(merged_sequences[-1], seq):
                     # Extend the previous (kept) sequence over this one.
                     previous = merged_sequences[-1]
-                    if verbose:
-                        print(
-                            f"Merging visit {visit.id} sequence {seq.id} "
-                            f"into {previous.id} "
-                            f"(target {previous.target}): stop "
-                            f"{previous.stop_time_str} -> {seq.stop_time_str}"
-                        )
+                    self._print(
+                        f"{self._seq_prefix(visit.id, previous)} | MERGE: "
+                        f"absorbing sequence {seq.id} "
+                        f"({self._seq_prefix(visit.id, seq)}); stop "
+                        f"{previous.stop_time_str} -> {seq.stop_time_str}"
+                    )
                     previous.stop_time = seq.stop_time
                     merged_count += 1
                 else:
@@ -672,11 +689,10 @@ class ScheduleProcessor:
 
             new_visits.append(Visit(id=visit.id, sequences=merged_sequences))
 
-        if verbose:
-            print(
-                f"Merged {merged_count} similar observation sequence(s) "
-                f"across {len(calendar.visits)} visit(s)."
-            )
+        self._print(
+            f"Merged {merged_count} similar observation sequence(s) "
+            f"across {len(calendar.visits)} visit(s)."
+        )
 
         return ScienceCalendar(
             metadata=calendar.metadata,
@@ -732,6 +748,14 @@ class ScheduleProcessor:
 
         working_calendar = deepcopy(calendar)
 
+        # Snapshot each sequence's original timing so any shrink/elongate
+        # performed by the gap-fill / trim passes below can be logged.
+        original_timing = {
+            (visit.id, seq.id): (seq.start_time, seq.stop_time)
+            for visit in working_calendar.visits
+            for seq in visit.sequences
+        }
+
         # ── Pre-compute best roll per target per visit ──────────
         # Only run the sweep when star-tracker constraints are active;
         # boresight-only constraints are roll-independent.
@@ -744,9 +768,8 @@ class ScheduleProcessor:
                     min_power_frac=self.min_power_frac,
                 )
                 self._computed_target_rolls[visit.id] = visit_rolls
-                if verbose:
-                    for tgt, r in visit_rolls.items():
-                        print(f"  Visit {visit.id} / {tgt}: best roll = {r}")
+                for tgt, r in visit_rolls.items():
+                    self._print(f"  Visit {visit.id} / {tgt}: best roll = {r}")
 
         # Use initial time grid for processing
         total_minutes, start_time, end_time, time_grid = (
@@ -767,10 +790,11 @@ class ScheduleProcessor:
                     np.rint((seq.start_time - last_stop).sec / 60.0)
                 )
                 if gap_length > 0:
-                    if verbose:
-                        print(
-                            f"Filling {gap_length} min gap before sequence {seq.id}"
-                        )
+                    self._print(
+                        f"{self._seq_prefix(visit.id, seq)} | GAP-FILL: "
+                        f"extending start earlier by {gap_length} min to "
+                        f"fill gap before this sequence"
+                    )
 
                     if not self.force_gap_fill:
                         seq = self._fill_gaps(
@@ -804,8 +828,7 @@ class ScheduleProcessor:
         # Fill remaining time after last sequence
         if i < total_minutes:
             all_minutes_bool[i:] = False
-            if verbose:
-                print(f"Filled trailing {total_minutes - i} minutes as False")
+            self._print(f"Filled trailing {total_minutes - i} minutes as False")
 
         self.all_minutes_bool = (
             all_minutes_bool  # this is only necessary for testing.
@@ -831,10 +854,46 @@ class ScheduleProcessor:
                 working_calendar
             )
 
+        # Report any timing changes (shrink/elongate) made above.
+        self._log_timing_changes(working_calendar, original_timing)
+
         # last thing is to update all the payload parameters
         working_calendar = self._update_payload_parameters(working_calendar)
 
         return working_calendar
+
+    def _log_timing_changes(
+        self, calendar: ScienceCalendar, original_timing: Dict[Any, Any]
+    ) -> None:
+        """Log per-sequence shrink/elongate vs the snapshot in
+        *original_timing* (keyed by ``(visit_id, sequence_id)``)."""
+        for visit in calendar.visits:
+            for seq in visit.sequences:
+                orig = original_timing.get((visit.id, seq.id))
+                if orig is None:
+                    continue
+                old_start, old_stop = orig
+                d_start = (seq.start_time - old_start).sec
+                d_stop = (seq.stop_time - old_stop).sec
+                if abs(d_start) < 1.0 and abs(d_stop) < 1.0:
+                    continue
+
+                parts = []
+                if abs(d_start) >= 1.0:
+                    where = "earlier" if d_start < 0 else "later"
+                    parts.append(f"start {where} {abs(d_start) / 60:.1f} min")
+                if abs(d_stop) >= 1.0:
+                    where = "later" if d_stop > 0 else "earlier"
+                    parts.append(f"stop {where} {abs(d_stop) / 60:.1f} min")
+
+                old_dur = (old_stop - old_start).sec / 60.0
+                new_dur = seq.duration.sec / 60.0
+                verb = "ELONGATED" if new_dur > old_dur else "SHRANK"
+                self._print(
+                    f"{self._seq_prefix(visit.id, seq)} | {verb}: "
+                    + ", ".join(parts)
+                    + f" (duration {old_dur:.1f} -> {new_dur:.1f} min)"
+                )
 
     def _fill_gaps(
         self,
@@ -2079,7 +2138,9 @@ class ScheduleProcessor:
             visit_id = visit.id
             for seq in visit.sequences:
                 sequence_id = seq.id
-                new_sequence = self._update_payload_parameters_sequence(seq)
+                new_sequence = self._update_payload_parameters_sequence(
+                    seq, visit_id=visit_id
+                )
                 calendar.replace_sequence(visit_id, sequence_id, new_sequence)
 
         return calendar
@@ -2116,6 +2177,9 @@ class ScheduleProcessor:
         override_fields = set(override_fields or ())
         default_config = data_cls().get_config()
         kwargs: Dict[str, Any] = dict(extra_kwargs or {})
+        # Share the run logger so the data class's own warnings (zero frame
+        # time, oversize, VITL fallback, ...) land in the same log.
+        kwargs.setdefault("logger", getattr(self, "logger", None))
         writeback: Dict[str, str] = {}
         missing: List[str] = []
 
@@ -2146,47 +2210,49 @@ class ScheduleProcessor:
         detector: str,
         data: u.Quantity,
         data_compressed: u.Quantity,
+        visit_id: Any = None,
     ) -> None:
         """Warn if a sequence's computed data volume exceeds the limits.
 
         Compares the *uncompressed* ``data`` against
         ``max_file_size_uncompressed`` and the *compressed*
-        ``data_compressed`` against ``max_file_size_compressed``, emitting a
-        ``UserWarning`` for each limit that is exceeded.
+        ``data_compressed`` against ``max_file_size_compressed``. Each
+        breach is emitted both as a ``UserWarning`` (for programmatic
+        consumers) and through the run logger so it lands in the console and
+        the ``.errors.log``.
         """
         max_uncompressed = getattr(self, "max_file_size_uncompressed", None)
         max_compressed = getattr(self, "max_file_size_compressed", None)
 
-        seq_id = (
-            f"{detector} sequence {sequence.id} "
-            f"({sequence.target} @ {sequence.start_time.isot})"
-        )
+        prefix = self._seq_prefix(visit_id, sequence)
 
         if (
             max_uncompressed is not None
             and data.to(u.byte).value > max_uncompressed.to(u.byte).value
         ):
-            warnings.warn(
-                f"{seq_id}: uncompressed data "
+            msg = (
+                f"{prefix} | {detector} uncompressed data "
                 f"{data.to(u.byte).value / 1e6:.1f} MB exceeds limit "
-                f"{max_uncompressed.to(u.byte).value / 1e6:.1f} MB",
-                stacklevel=2,
+                f"{max_uncompressed.to(u.byte).value / 1e6:.1f} MB"
             )
+            self._print(f"Warning: {msg}")
+            warnings.warn(msg, stacklevel=2)
 
         if (
             max_compressed is not None
             and data_compressed.to(u.byte).value
             > max_compressed.to(u.byte).value
         ):
-            warnings.warn(
-                f"{seq_id}: compressed data "
+            msg = (
+                f"{prefix} | {detector} compressed data "
                 f"{data_compressed.to(u.byte).value / 1e6:.1f} MB exceeds "
-                f"limit {max_compressed.to(u.byte).value / 1e6:.1f} MB",
-                stacklevel=2,
+                f"limit {max_compressed.to(u.byte).value / 1e6:.1f} MB"
             )
+            self._print(f"Warning: {msg}")
+            warnings.warn(msg, stacklevel=2)
 
     def _update_payload_parameters_sequence(
-        self, sequence: ObservationSequence
+        self, sequence: ObservationSequence, visit_id: Any = None
     ) -> ObservationSequence:
         # Pass sequence.duration (TimeDelta) so both helpers receive the
         # correct type and the overhead subtraction uses a consistent unit.
@@ -2200,17 +2266,21 @@ class ScheduleProcessor:
         nirda_fields = nirda_overrides.get(sequence.priority, ())
         visda_fields = visda_overrides.get(sequence.priority, ())
 
+        overhead = getattr(self, "overhead", None)
+
         sequence = self._update_VDA_integrations(
             sequence,
             duration,
-            overhead=self.overhead,
+            overhead=overhead,
             override_fields=visda_fields,
+            visit_id=visit_id,
         )
         sequence = self._update_NIRDA_integrations(
             sequence,
             duration,
-            overhead=self.overhead,
+            overhead=overhead,
             override_fields=nirda_fields,
+            visit_id=visit_id,
         )
 
         return sequence
@@ -2221,6 +2291,7 @@ class ScheduleProcessor:
         duration: TimeDelta,
         overhead: Optional[OverheadTiming] = None,
         override_fields: Any = (),
+        visit_id: Any = None,
     ) -> ObservationSequence:
         """Set NumTotalFramesRequested using a ``VisdaData`` model.
 
@@ -2249,24 +2320,35 @@ class ScheduleProcessor:
             VisdaData,
             extra_kwargs={"read_time_per_frame_s": 0 * u.s},
         )
+        prefix = self._seq_prefix(visit_id, sequence)
         if visda is None:
-            print(
-                f"Warning: Missing VDA parameters for sequence "
-                f"{sequence.id} {sequence.start_time}: {', '.join(info)}"
+            self._print(
+                f"Warning: {prefix} | Missing VDA parameters: "
+                f"{', '.join(info)}"
             )
             return sequence
 
-        # Write any overridden parameters back onto the observation.
+        # Write any overridden parameters back onto the observation, logging
+        # each forced change.
         for tag, text in info.items():
+            old = sequence.get_payload_parameter(
+                "AcquireVisCamScienceData", tag
+            )
             sequence.set_payload_parameter(
                 "AcquireVisCamScienceData", tag, text
             )
+            self._print(
+                f"{prefix} | VISDA OVERRIDE: {tag} '{old}' -> '{text}'"
+            )
 
+        old_frames = sequence.get_payload_parameter(
+            "AcquireVisCamScienceData", "NumTotalFramesRequested"
+        )
         frames, data, data_compressed = visda.solve_integrations(
             duration.to(u.s), overhead
         )
         self._warn_if_data_exceeds_limits(
-            sequence, "VISDA", data, data_compressed
+            sequence, "VISDA", data, data_compressed, visit_id=visit_id
         )
 
         success = sequence.set_payload_parameter(
@@ -2274,10 +2356,15 @@ class ScheduleProcessor:
             "NumTotalFramesRequested",
             str(int(frames)),
         )
-        if not success:
-            print(
-                f"Warning: Failed to update NumTotalFramesRequested for "
-                f"sequence {sequence.id} {sequence.start_time}"
+        if success:
+            self._print(
+                f"{prefix} | VISDA NumTotalFramesRequested "
+                f"'{old_frames}' -> '{int(frames)}'"
+            )
+        else:
+            self._print(
+                f"Warning: {prefix} | Failed to update "
+                f"NumTotalFramesRequested"
             )
         return sequence
 
@@ -2287,6 +2374,7 @@ class ScheduleProcessor:
         duration: TimeDelta,
         overhead: Optional[OverheadTiming] = None,
         override_fields: Any = (),
+        visit_id: Any = None,
     ) -> ObservationSequence:
         """Set SC_Integrations using a ``NirdaData`` model.
 
@@ -2307,56 +2395,73 @@ class ScheduleProcessor:
         if overhead is None:
             overhead = getattr(self, "overhead", None) or OverheadTiming()
 
+        prefix = self._seq_prefix(visit_id, sequence)
+
         nirda, info = self._build_payload_data(
             sequence,
             override_fields,
             NirdaData,
         )
         if nirda is None:
-            seq_identifier = (
-                f"{sequence.id} ({sequence.target} @ "
-                f"{sequence.start_time.datetime.strftime('%m/%d %H:%M')})"
+            self._print(
+                f"Warning: {prefix} | Missing NIRDA parameters: "
+                f"{', '.join(info)}"
             )
-            print(
-                f"Warning: Missing NIRDA parameters for sequence "
-                f"{seq_identifier}"
-            )
-            print(f"Missing parameters: {', '.join(info)}")
             return sequence
 
-        # Write any overridden parameters back onto the observation.
+        # Write any overridden parameters back onto the observation, logging
+        # each forced change.
         for tag, text in info.items():
+            old = sequence.get_payload_parameter("AcquireInfCamImages", tag)
             sequence.set_payload_parameter("AcquireInfCamImages", tag, text)
+            self._print(
+                f"{prefix} | NIRDA OVERRIDE: {tag} '{old}' -> '{text}'"
+            )
 
         # Optionally adjust reset_frames_1 to cover the VITL settling time
         # before computing integrations, and persist the new SC_Resets1.
-        # This affects number of integrations so needs to be set before 
+        # This affects number of integrations so needs to be set before
         # those are calculated.
         if getattr(self, "update_nirda_reset1_for_vitl", False):
             vitl_settling_time = getattr(
                 self, "vitl_settling_time", 60.0 * u.s
             )
-            nirda.update_for_vitl(vitl_settling_time)
-            sequence.set_payload_parameter(
-                "AcquireInfCamImages",
-                "SC_Resets1",
-                str(int(nirda.reset_frames_1)),
+            old_resets1 = sequence.get_payload_parameter(
+                "AcquireInfCamImages", "SC_Resets1"
             )
+            nirda.update_for_vitl(vitl_settling_time)
+            new_resets1 = str(int(nirda.reset_frames_1))
+            sequence.set_payload_parameter(
+                "AcquireInfCamImages", "SC_Resets1", new_resets1
+            )
+            if str(old_resets1) != new_resets1:
+                self._print(
+                    f"{prefix} | VITL: SC_Resets1 '{old_resets1}' -> "
+                    f"'{new_resets1}' to cover "
+                    f"{vitl_settling_time.to(u.s).value:.1f} s settling"
+                )
 
+        old_integrations = sequence.get_payload_parameter(
+            "AcquireInfCamImages", "SC_Integrations"
+        )
         integrations, data, data_compressed = nirda.solve_integrations(
             duration.to(u.s), overhead
         )
         self._warn_if_data_exceeds_limits(
-            sequence, "NIRDA", data, data_compressed
+            sequence, "NIRDA", data, data_compressed, visit_id=visit_id
         )
 
         success = sequence.set_payload_parameter(
             "AcquireInfCamImages", "SC_Integrations", str(int(integrations))
         )
-        if not success:
-            print(
-                f"Warning: Failed to update SC_Integrations for sequence "
-                f"{sequence.id} {sequence.start_time}"
+        if success:
+            self._print(
+                f"{prefix} | NIRDA SC_Integrations "
+                f"'{old_integrations}' -> '{int(integrations)}'"
+            )
+        else:
+            self._print(
+                f"Warning: {prefix} | Failed to update SC_Integrations"
             )
 
         return sequence
@@ -2644,7 +2749,7 @@ class ScheduleProcessor:
                     issues.append(issue)
 
                     if report_issues:
-                        print(message)
+                        self._print(message)
 
         return issues
 
@@ -2681,11 +2786,130 @@ class ScheduleProcessor:
                     issues.append(issue)
 
                     if report_issues:
-                        print(
+                        self._print(
                             f"Target name issue: '{seq.target}' contains spaces (sequence {seq.id}, visit {visit.id})"
                         )
 
         return issues
+
+    # ------------------------------------------------------------------
+    # Logging
+    # ------------------------------------------------------------------
+    def _print(self, *args, **kwargs) -> None:
+        """Route a ``print``-style call through the run logger.
+
+        Joins *args* like ``print`` and logs the result. Messages whose
+        (stripped) text begins with "warning" or "error" are logged at
+        WARNING/ERROR level so they reach the console and the
+        ``.errors.log`` file; everything else is logged at INFO and only
+        reaches the console when ``verbose`` was set. If no run logger has
+        been configured (e.g. a bare processor in a unit test), falls back
+        to the builtin ``print``.
+        """
+        sep = kwargs.get("sep", " ")
+        message = sep.join(str(a) for a in args)
+
+        logger = getattr(self, "logger", None)
+        if logger is None:
+            print(message)
+            return
+
+        head = message.lstrip().lower()
+        if head.startswith("error"):
+            logger.error(message)
+        elif head.startswith("warning"):
+            logger.warning(message)
+        else:
+            logger.info(message)
+
+    def _setup_run_logging(
+        self,
+        calendar: ScienceCalendar,
+        verbose: bool,
+        log_path: Optional[Any] = None,
+    ) -> None:
+        """Configure ``self.logger`` for a processing run.
+
+        Two log files are written alongside (and named after) the input
+        calendar: ``<stem>.log`` captures everything, and
+        ``<stem>.errors.log`` captures only warnings/errors and is created
+        lazily (so it never appears when the run is clean).
+
+        Parameters
+        ----------
+        calendar : ScienceCalendar
+            Used to discover the source calendar path via
+            ``metadata['source_path']`` when *log_path* is not given.
+        verbose : bool
+            When True the console receives INFO and above; otherwise the
+            console receives only WARNING and above. The ``.log`` file
+            always receives INFO and above.
+        log_path : str or pathlib.Path, optional
+            Explicit base path for the log file. Its suffix is replaced with
+            ``.log``. If omitted, the calendar's ``source_path`` is used.
+            If neither is available, only console logging is configured.
+        """
+        logger = logging.getLogger(f"shortschedule.run.{id(self)}")
+        logger.setLevel(logging.INFO)
+        logger.propagate = False
+        # Drop any handlers from a previous run on this processor.
+        for handler in list(logger.handlers):
+            logger.removeHandler(handler)
+            try:
+                handler.close()
+            except Exception:
+                pass
+
+        fmt = logging.Formatter("%(asctime)s %(levelname)s %(message)s")
+
+        # Console handler: gated by verbose for INFO, always shows warnings.
+        console = logging.StreamHandler()
+        console.setLevel(logging.INFO if verbose else logging.WARNING)
+        console.setFormatter(fmt)
+        logger.addHandler(console)
+
+        # Resolve the log file base path.
+        base = log_path
+        if base is None:
+            source = (calendar.metadata or {}).get("source_path")
+            base = source
+        if base is not None:
+            base = Path(base)
+            log_file = base.with_suffix(".log")
+            errors_file = base.with_suffix(".errors.log")
+
+            file_handler = logging.FileHandler(
+                log_file, mode="w", encoding="utf-8"
+            )
+            file_handler.setLevel(logging.INFO)
+            file_handler.setFormatter(fmt)
+            logger.addHandler(file_handler)
+
+            # delay=True means the file is only created on first emit, so a
+            # clean run leaves no (empty) errors log behind.
+            errors_handler = logging.FileHandler(
+                errors_file, mode="w", encoding="utf-8", delay=True
+            )
+            errors_handler.setLevel(logging.WARNING)
+            errors_handler.setFormatter(fmt)
+            logger.addHandler(errors_handler)
+
+            self.logger = logger
+            self.logger.info(f"Logging to {log_file}")
+        else:
+            self.logger = logger
+
+    @staticmethod
+    def _seq_prefix(visit_id: Any, seq: ObservationSequence) -> str:
+        """Return the standard log prefix for an observation.
+
+        Format: ``<start datetime>-<target id>-<visit id>-<observation id>``.
+        """
+        try:
+            start = seq.start_time.isot
+        except Exception:
+            start = str(getattr(seq, "start_time", "?"))
+        return f"{start}-{seq.target}-{visit_id}-{seq.id}"
 
     def _initialize_gap_report(self) -> None:
         """Initialize/reset the gap report structure."""
@@ -2766,10 +2990,10 @@ class ScheduleProcessor:
                 original_gaps.append(gap_info)
                 total_gap_time += gap_duration
 
-                if verbose:
-                    print(
-                        f"Original gap: {gap_duration:.1f} min between {current_seq.id} and {next_seq.id}"
-                    )
+                self._print(
+                    f"Original gap: {gap_duration:.1f} min between "
+                    f"{current_seq.id} and {next_seq.id}"
+                )
 
         self.gap_report["visibility_analysis"]["original_gaps"] = original_gaps
         self.gap_report["processing_summary"][
@@ -2823,43 +3047,43 @@ class ScheduleProcessor:
         report = self.gap_report
         summary = report["processing_summary"]
 
-        print("\n" + "=" * 60)
-        print("VISIBILITY GAP ANALYSIS SUMMARY")
-        print("=" * 60)
+        self._print("\n" + "=" * 60)
+        self._print("VISIBILITY GAP ANALYSIS SUMMARY")
+        self._print("=" * 60)
 
-        print("\nORIGINAL CALENDAR:")
-        print(
+        self._print("\nORIGINAL CALENDAR:")
+        self._print(
             f"  Total Sequences: {report['original_calendar_stats']['total_sequences']}"
         )
-        print(
+        self._print(
             f"  Total Duration: {report['original_calendar_stats']['total_duration_hours']:.1f} hours"
         )
-        print(
+        self._print(
             f"  Duty Cycle: {report['original_calendar_stats']['duty_cycle_percent']:.1f}%"
         )
 
-        print("\nPROCESSED CALENDAR:")
-        print(
+        self._print("\nPROCESSED CALENDAR:")
+        self._print(
             f"  Total Sequences: {report['processed_calendar_stats']['total_sequences']}"
         )
-        print(
+        self._print(
             f"  Total Duration: {report['processed_calendar_stats']['total_duration_hours']:.1f} hours"
         )
-        print(
+        self._print(
             f"  Duty Cycle: {report['processed_calendar_stats']['duty_cycle_percent']:.1f}%"
         )
 
-        print("\nIMPROVEMENTS:")
-        print(
+        self._print("\nIMPROVEMENTS:")
+        self._print(
             f"  Duration Gained: {summary.get('duration_improvement_hours', 0):.1f} hours"
         )
-        print(
+        self._print(
             f"  Duty Cycle Improved: {summary.get('duty_cycle_improvement_percent', 0):.1f}%"
         )
-        print(f"  Sequences Modified: {summary.get('sequences_modified', 0)}")
+        self._print(f"  Sequences Modified: {summary.get('sequences_modified', 0)}")
 
         if "gaps_filled" in summary:
-            print(
+            self._print(
                 f"  Gaps Filled: {summary['gaps_filled']}/{summary['gaps_filled'] + summary['gaps_remaining']}"
             )
 
@@ -2886,18 +3110,18 @@ class ScheduleProcessor:
                 break
 
         if not target_seq:
-            print(f"Sequence {sequence_id} not found")
+            self._print(f"Sequence {sequence_id} not found")
             return
 
-        print(f"\n{'='*60}")
-        print(f"DEBUGGING SEQUENCE {sequence_id}: {target_seq.target}")
-        print(f"{'='*60}")
-        print(f"Visit ID: {target_visit_id}")
-        print(f"Start Time: {target_seq.start_time}")
-        print(f"Stop Time: {target_seq.stop_time}")
-        print(f"Duration: {target_seq.duration.sec/60:.1f} minutes")
-        print(f"Target: {target_seq.target}")
-        print(f"RA/Dec: {target_seq.ra:.3f}, {target_seq.dec:.3f}")
+        self._print(f"\n{'='*60}")
+        self._print(f"DEBUGGING SEQUENCE {sequence_id}: {target_seq.target}")
+        self._print(f"{'='*60}")
+        self._print(f"Visit ID: {target_visit_id}")
+        self._print(f"Start Time: {target_seq.start_time}")
+        self._print(f"Stop Time: {target_seq.stop_time}")
+        self._print(f"Duration: {target_seq.duration.sec/60:.1f} minutes")
+        self._print(f"Target: {target_seq.target}")
+        self._print(f"RA/Dec: {target_seq.ra:.3f}, {target_seq.dec:.3f}")
 
         # Check visibility minute by minute
         n_mins = int(np.rint(target_seq.duration.sec / 60.0))
@@ -2909,15 +3133,15 @@ class ScheduleProcessor:
 
         vis = self.visibility.get_visibility(target_coord, times)
 
-        print("\nMinute-by-minute visibility:")
+        self._print("\nMinute-by-minute visibility:")
         for i, (time, visible) in enumerate(zip(times, vis)):
             status = "✓ VISIBLE" if visible else "✗ NOT VISIBLE"
-            print(f"  Minute {i+1}: {time.isot} - {status}")
+            self._print(f"  Minute {i+1}: {time.isot} - {status}")
 
-        print("\nVisibility Summary:")
-        print(f"  Total minutes: {len(vis)}")
-        print(f"  Visible minutes: {np.sum(vis)}")
-        print(f"  Visibility fraction: {np.sum(vis)/len(vis):.3f}")
+        self._print("\nVisibility Summary:")
+        self._print(f"  Total minutes: {len(vis)}")
+        self._print(f"  Visible minutes: {np.sum(vis)}")
+        self._print(f"  Visibility fraction: {np.sum(vis)/len(vis):.3f}")
 
         return {
             "sequence": target_seq,
@@ -3000,7 +3224,7 @@ class ScheduleProcessor:
                 overlaps.append(overlap_issue)
 
                 if report_issues:
-                    print(message)
+                    self._print(message)
 
         return overlaps
 
@@ -3125,53 +3349,53 @@ class ScheduleProcessor:
 
         # Report issues if requested
         if report_issues:
-            print("\n" + "=" * 60)
-            print("SEQUENCE TIMING VALIDATION REPORT")
-            print("=" * 60)
+            self._print("\n" + "=" * 60)
+            self._print("SEQUENCE TIMING VALIDATION REPORT")
+            self._print("=" * 60)
 
             summary = issues["timing_summary"]
-            print(
+            self._print(
                 f"Total sequences analyzed: " f"{summary['total_sequences']}"
             )
-            print(f"Total timing issues found: " f"{summary['total_issues']}")
-            print()
+            self._print(f"Total timing issues found: " f"{summary['total_issues']}")
+            self._print()
 
             if issues["overlaps"]:
-                print(f"OVERLAPS ({len(issues['overlaps'])} found):")
+                self._print(f"OVERLAPS ({len(issues['overlaps'])} found):")
                 for i, ov in enumerate(issues["overlaps"]):
-                    print(f"  {i+1}. {ov['message']}")
+                    self._print(f"  {i+1}. {ov['message']}")
             else:
-                print("\u2713 OVERLAPS: None found")
+                self._print("\u2713 OVERLAPS: None found")
 
-            print()
+            self._print()
 
             if issues["short_sequences"]:
-                print(
+                self._print(
                     f"SHORT SEQUENCES "
                     f"({len(issues['short_sequences'])} found, "
                     f"< {min_dur_min:.0f} min):"
                 )
                 for i, sh in enumerate(issues["short_sequences"]):
-                    print(f"  {i+1}. {sh['message']}")
+                    self._print(f"  {i+1}. {sh['message']}")
             else:
-                print("\u2713 SHORT SEQUENCES: None found")
+                self._print("\u2713 SHORT SEQUENCES: None found")
 
-            print()
+            self._print()
 
             if issues["large_gaps"]:
-                print(
+                self._print(
                     f"LARGE GAPS ({len(issues['large_gaps'])} "
                     f"found, > 2 min):"
                 )
                 for i, gap in enumerate(issues["large_gaps"][:5]):
-                    print(f"  {i+1}. {gap['message']}")
+                    self._print(f"  {i+1}. {gap['message']}")
                 if len(issues["large_gaps"]) > 5:
-                    print(
+                    self._print(
                         f"     ... and "
                         f"{len(issues['large_gaps']) - 5} more"
                     )
             else:
-                print("\u2713 LARGE GAPS: None found")
+                self._print("\u2713 LARGE GAPS: None found")
 
         return issues
 
@@ -3269,7 +3493,7 @@ class ScheduleProcessor:
                                 }
                             )
                             if report_issues:
-                                print(msg)
+                                self._print(msg)
 
                         if num_frames is not None:
                             try:
@@ -3321,7 +3545,7 @@ class ScheduleProcessor:
                                         }
                                     )
                                     if report_issues:
-                                        print(msg)
+                                        self._print(msg)
                             except (ValueError, TypeError):
                                 pass
 
@@ -3367,7 +3591,7 @@ class ScheduleProcessor:
                                         }
                                     )
                                     if report_issues:
-                                        print(msg)
+                                        self._print(msg)
                             except (ValueError, TypeError):
                                 pass
 
@@ -3417,7 +3641,7 @@ class ScheduleProcessor:
                                 }
                             )
                             if report_issues:
-                                print(msg)
+                                self._print(msg)
 
         return issues
 
@@ -3512,7 +3736,7 @@ class ScheduleProcessor:
                                 }
                                 issues.append(issue)
                                 if report_issues:
-                                    print(
+                                    self._print(
                                         f"STAR ROI ISSUE: sequence {seq.id} "
                                         f"StarRoiDetMethod=2 but "
                                         f"numPredefinedStarRois={num_predefined_val} (should be 0)"
@@ -3528,7 +3752,7 @@ class ScheduleProcessor:
                             }
                             issues.append(issue)
                             if report_issues:
-                                print(
+                                self._print(
                                     f"STAR ROI ISSUE: sequence {seq.id} "
                                     f"numPredefinedStarRois='{num_predefined}' cannot be parsed as integer"
                                 )
@@ -3547,7 +3771,7 @@ class ScheduleProcessor:
                                 }
                                 issues.append(issue)
                                 if report_issues:
-                                    print(
+                                    self._print(
                                         f"STAR ROI ISSUE: sequence {seq.id} "
                                         f"StarRoiDetMethod=2 but "
                                         f"MaxNumStarRois={max_num_val} (should be > 0)"
@@ -3563,7 +3787,7 @@ class ScheduleProcessor:
                             }
                             issues.append(issue)
                             if report_issues:
-                                print(
+                                self._print(
                                     f"STAR ROI ISSUE: sequence {seq.id} "
                                     f"MaxNumStarRois='{max_num}' cannot be parsed as integer"
                                 )
@@ -3586,7 +3810,7 @@ class ScheduleProcessor:
                                 }
                                 issues.append(issue)
                                 if report_issues:
-                                    print(
+                                    self._print(
                                         f"STAR ROI ISSUE: sequence {seq.id} "
                                         f"StarRoiDetMethod={method}, "
                                         f"MaxNumStarRois ({max_num_val}) != "
@@ -3605,7 +3829,7 @@ class ScheduleProcessor:
                             }
                             issues.append(issue)
                             if report_issues:
-                                print(
+                                self._print(
                                     f"STAR ROI ISSUE: sequence {seq.id} "
                                     f"numPredefinedStarRois='{num_predefined}' or "
                                     f"MaxNumStarRois='{max_num}' cannot be parsed as integers"
@@ -3689,7 +3913,7 @@ class ScheduleProcessor:
                         }
                     )
                     if report_issues:
-                        print(msg)
+                        self._print(msg)
 
         return issues
 
@@ -3706,7 +3930,7 @@ class ScheduleProcessor:
                     status = "PASS" if info["passes"] else "FAIL"
                     side = info.get("side", "")
                     side_label = f" [{side}]" if side else ""
-                    print(
+                    self._print(
                         f"{indent}{body:<12} {status}  "
                         f"required: >= {info['required_deg']:.1f}°"
                         f"{side_label}  "
@@ -3716,7 +3940,7 @@ class ScheduleProcessor:
             nv = item.get("non_visible_minutes")
             tot = item.get("total_minutes")
             if frac is not None:
-                print(
+                self._print(
                     f"{indent}{'visibility':<12}       "
                     f"required: 100%  "
                     f"actual: {frac:.1%}  "
@@ -3727,7 +3951,7 @@ class ScheduleProcessor:
             dur = item.get("duration_minutes")
             req = item.get("minimum_required_minutes")
             if dur is not None and req is not None:
-                print(
+                self._print(
                     f"{indent}duration     "
                     f"required: >= {req:.0f} min  "
                     f"actual: {dur:.1f} min  "
@@ -3737,7 +3961,7 @@ class ScheduleProcessor:
         elif category == "large_gaps":
             gap = item.get("gap_duration_minutes")
             if gap is not None:
-                print(
+                self._print(
                     f"{indent}gap          "
                     f"required: <= 2.0 min  "
                     f"actual: {gap:.1f} min  "
@@ -3747,7 +3971,7 @@ class ScheduleProcessor:
         elif category == "overlaps":
             ov = item.get("overlap_duration_minutes")
             if ov is not None:
-                print(
+                self._print(
                     f"{indent}overlap      "
                     f"required: 0.0 min  "
                     f"actual: {ov:.1f} min"
@@ -3758,7 +3982,7 @@ class ScheduleProcessor:
             eff_dur = item.get("effective_duration_seconds")
             oh = item.get("overhead_seconds")
             if seq_dur is not None:
-                print(
+                self._print(
                     f"{indent}sequence     "
                     f"{seq_dur:.0f}s total  "
                     f"- {oh:.0f}s overhead  "
@@ -3766,7 +3990,7 @@ class ScheduleProcessor:
                 )
             if "exposure_seconds" in item:
                 exp = item["exposure_seconds"]
-                print(
+                self._print(
                     f"{indent}single exp   "
                     f"required: <= {eff_dur:.0f}s  "
                     f"actual: {exp:.3f}s"
@@ -3774,7 +3998,7 @@ class ScheduleProcessor:
             if "total_exposure_seconds" in item:
                 tot = item["total_exposure_seconds"]
                 max_f = item.get("suggested_max_frames", "?")
-                print(
+                self._print(
                     f"{indent}total exp    "
                     f"required: <= {eff_dur:.0f}s  "
                     f"actual: {tot:.1f}s  "
@@ -3782,7 +4006,7 @@ class ScheduleProcessor:
                 )
             if "coadd_exposure_seconds" in item:
                 coadd = item["coadd_exposure_seconds"]
-                print(
+                self._print(
                     f"{indent}coadd exp    "
                     f"required: <= {eff_dur:.0f}s  "
                     f"actual: {coadd:.1f}s"
@@ -3790,7 +4014,7 @@ class ScheduleProcessor:
             if "value_seconds" in item:
                 val = item["value_seconds"]
                 field = item.get("field", "?")
-                print(
+                self._print(
                     f"{indent}{field}  "
                     f"required: <= {eff_dur:.0f}s  "
                     f"actual: {val:.3f}s"
@@ -3800,7 +4024,7 @@ class ScheduleProcessor:
             spread = item.get("max_difference_deg")
             suggested = item.get("suggested_roll")
             if spread is not None:
-                print(
+                self._print(
                     f"{indent}roll spread  "
                     f"required: <= 0.001°  "
                     f"actual: {spread:.3f}°  "
@@ -3810,7 +4034,7 @@ class ScheduleProcessor:
         elif category == "target_name":
             tgt = item.get("target", "")
             if tgt:
-                print(
+                self._print(
                     f"{indent}target name  "
                     f"required: no spaces  "
                     f"actual: '{tgt}'"
@@ -3882,7 +4106,7 @@ class ScheduleProcessor:
         status = "VALID" if total == 0 else "INVALID"
 
         # ── Print ──
-        print(
+        self._print(
             f"\n{'=' * 60}\n"
             f"  VALIDATION SUMMARY: {status} "
             f"({total} issues)\n"
@@ -3890,7 +4114,7 @@ class ScheduleProcessor:
         )
 
         if total == 0:
-            print("  All checks passed.\n")
+            self._print("  All checks passed.\n")
             return {
                 "status": status,
                 "counts": counts,
@@ -3898,7 +4122,7 @@ class ScheduleProcessor:
             }
 
         for cat, cnt in counts.items():
-            print(f"\n  [{cat.upper()}] — {cnt} issue(s)")
+            self._print(f"\n  [{cat.upper()}] — {cnt} issue(s)")
             items = results[cat]
 
             # Sequence timing has a nested structure
@@ -3911,7 +4135,7 @@ class ScheduleProcessor:
                     for item in items.get(sub_key, []):
                         msg = item.get("message", "")
                         if msg:
-                            print(f"    • {msg}")
+                            self._print(f"    • {msg}")
                         self._print_issue_details(sub_key, item)
                 continue
 
@@ -3920,10 +4144,10 @@ class ScheduleProcessor:
                 for item in items:
                     msg = item.get("message", "")
                     if msg:
-                        print(f"    • {msg}")
+                        self._print(f"    • {msg}")
                     self._print_issue_details(cat, item)
 
-        print(f"\n{'=' * 60}\n")
+        self._print(f"\n{'=' * 60}\n")
         return {
             "status": status,
             "counts": counts,
@@ -3936,17 +4160,17 @@ class ScheduleProcessor:
         summary = issues["timing_summary"]
 
         if summary["total_issues"] == 0:
-            print("✓ All sequence timing validation checks passed")
+            self._print("✓ All sequence timing validation checks passed")
         else:
-            print(f"✗ Found {summary['total_issues']} timing issues:")
+            self._print(f"✗ Found {summary['total_issues']} timing issues:")
             if summary["overlaps_found"]:
-                print(f"  - {summary['overlaps_found']} overlaps")
+                self._print(f"  - {summary['overlaps_found']} overlaps")
             if summary["short_sequences_found"]:
-                print(
+                self._print(
                     f"  - {summary['short_sequences_found']} sequences too short"
                 )
             if summary["large_gaps_found"]:
-                print(f"  - {summary['large_gaps_found']} large gaps")
+                self._print(f"  - {summary['large_gaps_found']} large gaps")
 
 
 def _find_false_blocks(vis_bool, time_grid, return_index=False):

--- a/src/shortschedule/visda.py
+++ b/src/shortschedule/visda.py
@@ -210,7 +210,10 @@ class VisdaData:
             Number of frames that fit in the available time, floored to a
             whole number of coadds.
         data : Quantity[byte]
-            Total raw data volume for those frames.
+            Total raw data volume *downlinked* for those frames. On-board
+            coadding combines ``frames_per_coadd`` consecutive frames into a
+            single saved frame, so the saved volume is the number of coadds
+            times ``frame_bytes`` (not the raw pre-coadd frame count).
         data_compressed : Quantity[byte]
             Total compressed data volume.
         """
@@ -243,7 +246,11 @@ class VisdaData:
         if self.frames_per_coadd > 0:
             frames = max(0, frames - (frames % self.frames_per_coadd))
 
-        data = frames * self.frame_bytes
+        if self.frames_per_coadd > 0:
+            coadds = frames // self.frames_per_coadd
+        else:
+            coadds = frames
+        data = coadds * self.frame_bytes
         return (frames, data, data * self.compression_ratio)
 
     def solve_duration(
@@ -266,7 +273,8 @@ class VisdaData:
         duration : Quantity[second]
             Total wall-clock time needed, including all overheads.
         data : Quantity[byte]
-            Total raw data volume for those frames.
+            Total raw data volume *downlinked* for those frames (net of
+            on-board coadding; see :meth:`solve_integrations`).
         data_compressed : Quantity[byte]
             Total compressed data volume.
         """
@@ -282,7 +290,11 @@ class VisdaData:
             + overhead.visda_post_overhead_time
             + self.additional_overhead_time
         )
-        data = integrations * self.frame_bytes
+        if self.frames_per_coadd > 0:
+            coadds = integrations // self.frames_per_coadd
+        else:
+            coadds = integrations
+        data = coadds * self.frame_bytes
 
         if integrations == 0:
             duration = 0.0 * u.s

--- a/src/shortschedule/visda.py
+++ b/src/shortschedule/visda.py
@@ -229,7 +229,15 @@ class VisdaData:
             - overhead.visda_post_overhead_time
             - self.additional_overhead_time
         )
-        buffered_time = max(0, buffered_time.value) * u.s
+        # Snap to the nearest microsecond before flooring. astropy ``Time``
+        # subtraction (e.g. computing a merged sequence's duration) carries
+        # sub-microsecond floating-point noise that varies with the absolute
+        # epoch, so an exact integer frame count can land at, say,
+        # 11389.9999998 and floor down a whole frame, which the
+        # coadd-multiple flooring below then amplifies into a lost coadd.
+        # Microsecond precision is far finer than one exposure, so this snap
+        # is physically lossless.
+        buffered_time = max(0.0, round(buffered_time.to(u.s).value, 6)) * u.s
 
         # Find total number of frames that can fit into our observation time.
         if self.single_frame_time.to(u.s).value <= 0:

--- a/src/shortschedule/visda.py
+++ b/src/shortschedule/visda.py
@@ -29,6 +29,26 @@ from typing import TYPE_CHECKING
 if TYPE_CHECKING:
     from .overhead import OverheadTiming
 
+
+# Converters between payload XML text and VisdaData config values. Payload
+# values are sometimes written as floats (e.g. "5.0"), so ints are parsed
+# via float first. Exposure time is stored on the payload in microseconds.
+def _xml_to_int(value: str) -> int:
+    return int(float(value))
+
+
+def _int_to_xml(value) -> str:
+    return str(int(value))
+
+
+def _xml_to_exposure(value: str) -> Quantity:
+    return int(float(value)) * u.us
+
+
+def _exposure_to_xml(value: Quantity) -> str:
+    return str(int(value.to(u.us).value))
+
+
 @dataclass
 class VisdaData:
     """VISDA timing and data-volume parameters for a single observation.
@@ -79,6 +99,31 @@ class VisdaData:
     dropped_integration_time : Quantity[second]
         Wall-clock duration of the dropped-frame buffer.
     """
+
+    # Payload (PAN-SCICAL XML) integration. These are plain class attributes
+    # (no annotations) so the dataclass does not treat them as fields.
+    #
+    # PAYLOAD_SECTION : the payload element these config fields live under.
+    # CONFIG_SPEC     : maps a config field -> (xml_tag, from_xml, to_xml),
+    #                   describing how to read/write each field from/to the
+    #                   payload XML.
+    # REQUIRED_CONFIG_FIELDS : fields needed to compute
+    #                   NumTotalFramesRequested (the ROI fields only affect
+    #                   data volume, so they are optional).
+    PAYLOAD_SECTION = "AcquireVisCamScienceData"
+    CONFIG_SPEC = {
+        "exposure_time_s": (
+            "ExposureTime_us",
+            _xml_to_exposure,
+            _exposure_to_xml,
+        ),
+        "frames_per_coadd": ("FramesPerCoadd", _xml_to_int, _int_to_xml),
+        "roi_dimension": ("StarRoiDimension", _xml_to_int, _int_to_xml),
+        "num_rois": ("MaxNumStarRois", _xml_to_int, _int_to_xml),
+    }
+    REQUIRED_CONFIG_FIELDS = frozenset(
+        ("exposure_time_s", "frames_per_coadd")
+    )
 
     # VISDA observation configurations
     frames_per_coadd: int = 5
@@ -226,3 +271,17 @@ class VisdaData:
             duration = integrations * self.single_frame_time + overhead_time
 
         return (duration, data, data * self.compression_ratio)
+    
+    def get_config(self) -> dict:
+        """Return the current payload-config field values.
+
+        Returns
+        -------
+        dict
+            Maps each :data:`CONFIG_SPEC` field name to this instance's
+            current value (e.g. ``{'frames_per_coadd': 5,
+            'exposure_time_s': <Quantity 0.2 s>, ...}``). Useful for reading
+            the default detector configuration when applying per-field
+            overrides.
+        """
+        return {field: getattr(self, field) for field in self.CONFIG_SPEC}

--- a/src/shortschedule/visda.py
+++ b/src/shortschedule/visda.py
@@ -17,12 +17,17 @@ to acquire, and ``frames_per_coadd`` consecutive frames are combined into a
 single coadd before downlink.
 """
 
+from __future__ import annotations
+
 import math
 from dataclasses import dataclass, field
 
 from astropy import units as u
 from astropy.units import Quantity
 
+from typing import TYPE_CHECKING
+if TYPE_CHECKING:
+    from .overhead import OverheadTiming
 
 @dataclass
 class VisdaData:
@@ -123,8 +128,7 @@ class VisdaData:
     def solve_integrations(
         self,
         duration: Quantity,
-        pre_overhead_time: Quantity = 258.0 * u.s,
-        post_overhead_time: Quantity = 102.0 * u.s,
+        overhead: OverheadTiming = None
     ):
         """Compute the number of frames that fit within a duration.
 
@@ -132,10 +136,9 @@ class VisdaData:
         ----------
         duration : Quantity[second]
             Total available observation time.
-        pre_overhead_time : Quantity[second], optional
-            Fixed overhead before science frames begin.
-        post_overhead_time : Quantity[second], optional
-            Fixed overhead after science frames end.
+        overhead : OverheadTiming, default=None
+            Overhead timings for nirda and visda.
+            If None, then use default overheads.
 
         Returns
         -------
@@ -147,11 +150,17 @@ class VisdaData:
         data_compressed : Quantity[byte]
             Total compressed data volume.
         """
+
+        if overhead is None:
+            # Use default overheads
+            from .overhead import OverheadTiming
+            overhead = OverheadTiming()
+
         buffered_time = (
-            duration.to(u.s)
-            - pre_overhead_time.to(u.s)
-            - post_overhead_time.to(u.s)
-            - self.additional_overhead_time.to(u.s)
+            duration
+            - overhead.visda_pre_overhead_time
+            - overhead.visda_post_overhead_time
+            - self.additional_overhead_time
         )
         buffered_time = max(0, buffered_time.value) * u.s
 
@@ -176,8 +185,7 @@ class VisdaData:
     def solve_duration(
         self,
         integrations: int,
-        pre_overhead_time: Quantity = 258.0 * u.s,
-        post_overhead_time: Quantity = 102.0 * u.s,
+        overhead: OverheadTiming = None
     ):
         """Compute the total duration required to acquire a given number of frames.
 
@@ -185,10 +193,9 @@ class VisdaData:
         ----------
         integrations : int
             Desired number of frames.
-        pre_overhead_time : Quantity[second], optional
-            Fixed overhead before science frames begin.
-        post_overhead_time : Quantity[second], optional
-            Fixed overhead after science frames end.
+        overhead : OverheadTiming, default=None
+            Overhead timings for nirda and visda.
+            If None, then use default overheads.
 
         Returns
         -------
@@ -199,8 +206,18 @@ class VisdaData:
         data_compressed : Quantity[byte]
             Total compressed data volume.
         """
+
+        if overhead is None:
+            # Use default overheads
+            from .overhead import OverheadTiming
+            overhead = OverheadTiming()
+
         integrations = max(0, integrations)
-        overhead_time = pre_overhead_time + post_overhead_time + self.additional_overhead_time
+        overhead_time = (
+            overhead.visda_pre_overhead_time
+            + overhead.visda_post_overhead_time
+            + self.additional_overhead_time
+        )
         data = integrations * self.frame_bytes
 
         if integrations == 0:

--- a/src/shortschedule/visda.py
+++ b/src/shortschedule/visda.py
@@ -19,6 +19,7 @@ single coadd before downlink.
 
 from __future__ import annotations
 
+from warnings import warn
 import math
 from dataclasses import dataclass, field
 
@@ -138,7 +139,7 @@ class VisdaData:
     visimg_bytes_per_pixel: Quantity = 2 * u.byte
     read_time_per_frame_s: Quantity = 1.0e-6 * u.s  # This is not correct but this parameter is effectively 0 compared to the exposure time.
     additional_overhead_time: Quantity = 0 * u.s
-    dropped_frames: int = 0
+    dropped_frames: int = 1  # TODO: As a buffer we drop one VISDA frame
 
     # Derived attributes: computed in _update_derived, not constructor arguments
     pixels_per_frame: int = field(init=False)
@@ -160,14 +161,20 @@ class VisdaData:
             bytes_per_pixel = self.visimg_bytes_per_pixel
 
         self.frame_bytes = max(
-            0, (self.pixels_per_frame * bytes_per_pixel).to(u.byte).value
+            0,
+            (self.pixels_per_frame * bytes_per_pixel).to(u.byte).value
         ) * u.byte
         self.coadd_bytes = self.frame_bytes * self.frames_per_coadd
+        if self.coadd_bytes == 0.0 * u.s:
+            warn("VISDA: Data size of one coadd was found to be 0.")
 
         self.single_frame_time = max(
             0,
             (self.exposure_time_s.to(u.s) + self.read_time_per_frame_s.to(u.s)).value,
         ) * u.s
+        if self.single_frame_time == 0.0 * u.s:
+            warn("VISDA: Single frame time found to be 0.")
+
         self.dropped_integration_time = self.dropped_frames * self.single_frame_time
 
     def solve_integrations(

--- a/src/shortschedule/visda.py
+++ b/src/shortschedule/visda.py
@@ -26,7 +26,7 @@ from dataclasses import dataclass, field
 from astropy import units as u
 from astropy.units import Quantity
 
-from typing import TYPE_CHECKING
+from typing import Any, TYPE_CHECKING
 if TYPE_CHECKING:
     from .overhead import OverheadTiming
 
@@ -148,8 +148,20 @@ class VisdaData:
     single_frame_time: Quantity = field(init=False)
     dropped_integration_time: Quantity = field(init=False)
 
+    # Optional logger. When provided (e.g. by ScheduleProcessor) warnings are
+    # sent to it so they share the run log; otherwise ``warnings.warn`` is
+    # used. Excluded from repr/equality so it never affects data comparisons.
+    logger: Any = field(default=None, repr=False, compare=False)
+
     def __post_init__(self):
         self._update_derived()
+
+    def _warn(self, message: str) -> None:
+        """Emit a warning via the attached logger, or ``warnings.warn``."""
+        if self.logger is not None:
+            self.logger.warning(message)
+        else:
+            warn(message)
 
     def _update_derived(self):
         """Recompute all derived timing and data-volume attributes."""
@@ -166,14 +178,14 @@ class VisdaData:
         ) * u.byte
         self.coadd_bytes = self.frame_bytes * self.frames_per_coadd
         if self.coadd_bytes == 0.0 * u.s:
-            warn("VISDA: Data size of one coadd was found to be 0.")
+            self._warn("VISDA: Data size of one coadd was found to be 0.")
 
         self.single_frame_time = max(
             0,
             (self.exposure_time_s.to(u.s) + self.read_time_per_frame_s.to(u.s)).value,
         ) * u.s
         if self.single_frame_time == 0.0 * u.s:
-            warn("VISDA: Single frame time found to be 0.")
+            self._warn("VISDA: Single frame time found to be 0.")
 
         self.dropped_integration_time = self.dropped_frames * self.single_frame_time
 

--- a/src/shortschedule/writer.py
+++ b/src/shortschedule/writer.py
@@ -216,12 +216,34 @@ class XMLWriter:
         if sequence.roll is not None:
             roll_elem = ET.SubElement(boresight_elem, "Roll")
             roll_elem.text = f"{sequence.roll:.6f}"
-        # PRI_CMD_DIR (always 9)
+        # PRI_CMD_DIR (default 9; may be overridden below)
         pri_cmd_dir_elem = ET.SubElement(boresight_elem, "PRI_CMD_DIR")
         pri_cmd_dir_elem.text = "9"
 
+        # Merge any Observational_Parameters override (e.g. a forced
+        # Boresight/PRI_CMD_DIR) into the block we just built.
+        obs_override = sequence.payload_params.get("Observational_Parameters")
+        if obs_override is not None:
+            self._merge_override_element(obs_params, obs_override)
+
         # Payload Parameters - copy the XML elements directly
         self._add_payload_parameters(seq_elem, sequence.payload_params)
+
+    def _merge_override_element(self, target, override):
+        """Recursively merge override children into ``target`` in place.
+
+        For each child of *override*, find or create the matching child in
+        *target*, copy its text when present, and recurse into nested
+        elements.
+        """
+        for child in override:
+            existing = target.find(child.tag)
+            if existing is None:
+                existing = ET.SubElement(target, child.tag)
+            if len(child):
+                self._merge_override_element(existing, child)
+            if child.text and child.text.strip():
+                existing.text = child.text.strip()
 
     def _add_payload_parameters(self, seq_elem, payload_params):
         """Add payload parameters section by copying XML elements."""
@@ -229,6 +251,10 @@ class XMLWriter:
 
         # Copy each payload parameter XML element directly
         for param_name, xml_element in payload_params.items():
+            # Observational_Parameters overrides are merged into the
+            # Observational_Parameters block elsewhere, not into Payload.
+            if param_name == "Observational_Parameters":
+                continue
             if xml_element is not None:
                 # Create a deep copy of the XML element
                 copied_element = self._deep_copy_xml_element(xml_element)

--- a/src/shortschedule/writer.py
+++ b/src/shortschedule/writer.py
@@ -134,6 +134,19 @@ class XMLWriter:
         """Add metadata element to root."""
         meta = ET.SubElement(root, "Meta")
 
+        # Stamp the short-term scheduler version that produced this calendar.
+        # Imported lazily to avoid a circular import at package init time.
+        version = metadata.get("short_term_scheduler_version")
+        if not version:
+            try:
+                from . import get_version
+
+                version = get_version()
+            except Exception:
+                version = None
+        if version:
+            meta.set("Short_Term_Scheduler_Version", str(version))
+
         # Standard metadata fields mapping
         meta_mapping = {
             "valid_from": "Valid_From",

--- a/tests/test_diagnostics.py
+++ b/tests/test_diagnostics.py
@@ -1,0 +1,175 @@
+"""Tests for ScheduleProcessor.generate_diagnostics (.diag report).
+
+Covers:
+- Week-summary header and per-day sections
+- Per-day priority counts, unique targets, observing/gap percentages
+- NIR/VIS frame and data totals (compressed + uncompressed) from the
+  detector data classes
+- Per-day file manifest
+- Day bucketing by largest UTC overlap
+- File is written to the requested path
+"""
+
+# Standard library
+import xml.etree.ElementTree as ET
+
+# Third-party
+from astropy import units as u
+from astropy.time import Time, TimeDelta
+
+# First-party/Local
+from shortschedule.models import ObservationSequence, ScienceCalendar, Visit
+from shortschedule.nirda import NirdaData
+from shortschedule.scheduler import ScheduleProcessor
+from shortschedule.visda import VisdaData
+
+
+def _sched():
+    return ScheduleProcessor.__new__(ScheduleProcessor)
+
+
+def _nir_payload(sc_integrations):
+    root = ET.Element(NirdaData.PAYLOAD_SECTION)
+    cfg = NirdaData().get_config()
+    for field, (tag, _from, to_xml) in NirdaData.CONFIG_SPEC.items():
+        ET.SubElement(root, tag).text = to_xml(cfg[field])
+    ET.SubElement(root, "SC_Integrations").text = str(sc_integrations)
+    return root
+
+
+def _vis_payload(num_total_frames):
+    root = ET.Element(VisdaData.PAYLOAD_SECTION)
+    cfg = VisdaData().get_config()
+    for field, (tag, _from, to_xml) in VisdaData.CONFIG_SPEC.items():
+        ET.SubElement(root, tag).text = to_xml(cfg[field])
+    ET.SubElement(root, "NumTotalFramesRequested").text = str(
+        num_total_frames
+    )
+    return root
+
+
+def _seq(sid, target, priority, start_iso, dur_min, sc_int=10, vis_frames=50):
+    start = Time(start_iso, scale="utc")
+    return ObservationSequence(
+        id=sid,
+        target=target,
+        priority=priority,
+        start_time=start,
+        stop_time=start + TimeDelta(dur_min * 60, format="sec"),
+        ra=10.0,
+        dec=20.0,
+        payload_params={
+            NirdaData.PAYLOAD_SECTION: _nir_payload(sc_int),
+            VisdaData.PAYLOAD_SECTION: _vis_payload(vis_frames),
+        },
+    )
+
+
+def _calendar():
+    # Day A: two sequences (one with a gap before the second); Day B: one.
+    v1 = Visit(
+        id="0001",
+        sequences=[
+            _seq("001", "TargetA", 0, "2026-03-01T00:00:00", 60),
+            _seq("002", "TargetB", 1, "2026-03-01T02:00:00", 60),
+        ],
+    )
+    v2 = Visit(
+        id="0002",
+        sequences=[
+            _seq("001", "TargetA", 2, "2026-03-02T00:00:00", 120),
+        ],
+    )
+    return ScienceCalendar(metadata={}, visits=[v1, v2])
+
+
+class TestGenerateDiagnostics:
+    def test_writes_file_and_returns_text(self, tmp_path):
+        sched = _sched()
+        out = tmp_path / "cal"
+        text = sched.generate_diagnostics(_calendar(), output_path=out)
+        assert (tmp_path / "cal.diag").exists()
+        assert text == (tmp_path / "cal.diag").read_text(encoding="utf-8")
+
+    def test_week_summary_header(self):
+        text = _sched().generate_diagnostics(_calendar())
+        assert "Calendar Summary 2026-03-01 : 2026-03-02" in text
+        assert "Total Observations: 3" in text
+        # Priorities: one each of 0, 1, 2.
+        assert "  - Priority 0 = 1" in text
+        assert "  - Priority 1 = 1" in text
+        assert "  - Priority 2 = 1" in text
+
+    def test_per_day_sections_present(self):
+        text = _sched().generate_diagnostics(_calendar())
+        assert "2026-03-01" in text
+        assert "2026-03-02" in text
+        assert "Number of Observations: 2" in text  # day A
+        assert "Number of Observations: 1" in text  # day B
+
+    def test_unique_targets_listed(self):
+        text = _sched().generate_diagnostics(_calendar())
+        assert "List of Unique Targets:" in text
+        assert "  - TargetA" in text
+        assert "  - TargetB" in text
+
+    def test_observing_and_gap_percentages(self):
+        text = _sched().generate_diagnostics(_calendar())
+        # Day A: 120 min observing, 60 min gap (between 01:00 and 02:00).
+        assert "Total Gaps: 60 Mins (33.3%)" in text
+        assert "Total Observing: 120 Mins (66.7%)" in text
+
+    def test_data_lines_and_passes(self):
+        text = _sched().generate_diagnostics(
+            _calendar(), pass_data_volume_mb=100.0
+        )
+        assert "Uncompressed Data" in text
+        assert "Required Passes:" in text
+        # Without a pass volume, passes are N/A.
+        text2 = _sched().generate_diagnostics(_calendar())
+        assert "Required Passes: N/A" in text2
+
+    def test_manifest_entries(self):
+        text = _sched().generate_diagnostics(_calendar())
+        assert "Manifest of Files for the Day:" in text
+        assert "- /mnt/data/sci/20260301T000000_TargetA.bin" in text
+        assert "- /mnt/data/sci/20260302T000000_TargetA.bin" in text
+
+    def test_manifest_lists_fits_products(self):
+        """Each .bin is followed by tab-indented InfImg/VisSci/engineering."""
+        text = _sched().generate_diagnostics(_calendar())
+        # Tab-indented FITS lines.
+        assert "\t- " in text
+        assert "_InfImg_TargetA_" in text
+        assert "_VisSci_TargetA_" in text
+        assert "_engineering.fits" in text
+        # InfImg cube depth = integrations * groups (10 * default groups=6=60)
+        # and the InfImg/VisSci/engineering names carry payload fields.
+        assert "_b1_e01_i10_g06_" in text
+        assert "_VisSci_TargetA_d050_n009_f00050_e000200000us.fits" in text
+
+    def test_fits_indented_under_bin(self):
+        """FITS lines are nested (tabbed) directly under their .bin line."""
+        lines = _sched().generate_diagnostics(_calendar()).splitlines()
+        bin_idx = next(
+            i for i, ln in enumerate(lines)
+            if ln.startswith("- /mnt/data/sci/20260302T000000_TargetA.bin")
+        )
+        # The lines immediately following the bin are tab-indented FITS files.
+        following = lines[bin_idx + 1:bin_idx + 4]
+        assert all(ln.startswith("\t- ") for ln in following)
+        assert any("_InfImg_" in ln for ln in following)
+        assert any("_engineering.fits" in ln for ln in following)
+
+    def test_nir_vis_frames_positive(self):
+        text = _sched().generate_diagnostics(_calendar())
+        # NIR frames = integrations * groups (averaged) > 0; VIS frames =
+        # coadds = NumTotalFrames // frames_per_coadd > 0.
+        assert "Total NIR Frames = " in text
+        assert "Total Vis Frames = " in text
+
+    def test_empty_calendar(self):
+        text = _sched().generate_diagnostics(
+            ScienceCalendar(metadata={}, visits=[])
+        )
+        assert "No observations" in text

--- a/tests/test_enhanced_validators.py
+++ b/tests/test_enhanced_validators.py
@@ -24,6 +24,7 @@ from shortschedule.models import (
     ScienceCalendar,
     Visit,
 )
+from shortschedule.overhead import OverheadTiming
 from shortschedule.scheduler import ScheduleProcessor
 
 # ================================================================
@@ -451,10 +452,12 @@ class TestValidateSequenceTiming:
 class TestValidatePayloadExposures:
     def _sched_with_overheads(self):
         sched = _bare_sched()
-        sched.vda_pre_sequence_overhead = 260 * u.s
-        sched.vda_post_sequence_overhead = 120 * u.s
-        sched.nirda_pre_sequence_overhead = 258 * u.s
-        sched.nirda_post_sequence_overhead = 120 * u.s
+        sched.overhead = OverheadTiming(
+            visda_pre_overhead_time=260 * u.s,
+            visda_post_overhead_time=120 * u.s,
+            nirda_pre_overhead_time=258 * u.s,
+            nirda_post_overhead_time=120 * u.s,
+        )
         return sched
 
     def test_no_issues_when_exposure_fits(self):

--- a/tests/test_gap_filling.py
+++ b/tests/test_gap_filling.py
@@ -430,7 +430,7 @@ class TestRollAwareGapFilling:
         ]
         assert 42.0 in roll_values
 
-    def test_end_to_end_roll_sensitive(self, monkeypatch):
+    def test_end_to_end_roll_sensitive(self, monkeypatch, tmp_path):
         """Full process_calendar with roll-sensitive visibility."""
         import shortschedule
 
@@ -457,6 +457,7 @@ class TestRollAwareGapFilling:
             cal,
             window_start=first_seq.start_time.isot,
             window_duration_days=1,
+            log_path=tmp_path / "run",
             verbose=False,
         )
 

--- a/tests/test_gap_filling.py
+++ b/tests/test_gap_filling.py
@@ -8,6 +8,9 @@ Covers:
 - Gap report structure verification
 """
 
+# Standard library
+from pathlib import Path
+
 # Third-party
 import numpy as np
 import pytest
@@ -431,9 +434,10 @@ class TestRollAwareGapFilling:
         """Full process_calendar with roll-sensitive visibility."""
         import shortschedule
 
-        pkgdir = shortschedule.__file__.rsplit("/", 1)[0]
         sample = (
-            pkgdir + "/data/Pandora_science_calendar_20251018_tsb-futz.xml"
+            Path(shortschedule.__file__).parent
+            / "data"
+            / "Pandora_science_calendar_20251018_tsb-futz.xml"
         )
 
         from shortschedule.parser import parse_science_calendar

--- a/tests/test_integration_counts.py
+++ b/tests/test_integration_counts.py
@@ -11,7 +11,11 @@ from astropy import units as u
 from astropy.time import Time, TimeDelta
 
 # First-party/Local
-from shortschedule.models import ObservationSequence
+from shortschedule.models import (
+    ObservationSequence,
+    ScienceCalendar,
+    Visit,
+)
 from shortschedule.nirda import NirdaData
 from shortschedule.overhead import OverheadTiming
 from shortschedule.scheduler import ScheduleProcessor
@@ -496,35 +500,35 @@ class TestUpdateNIRDAIntegrations:
         assert integ == expected
 
     def test_second_integration_fits_at_boundary(self):
-        """A window of first + other (plus a hair) fits two integrations.
+        """Extending a window by one ``other`` integration adds exactly one.
 
         NirdaData.solve_integrations fits the second integration as soon as
-        the remaining time reaches the "other" integration time, so a window
-        just past first + other yields two integrations.
+        the remaining time reaches the "other" integration time. The check is
+        framed as a delta so it stays valid regardless of any fixed offset
+        (e.g. dropped_integrations) applied to the reported count.
         """
         nd = _nirda_from_kwargs(**_NIRDA_KWARGS)
         first_integration_time = nd.first_integration_time.to(u.s).value
         other_integration_time = nd.other_integration_time.to(u.s).value
-        # Small positive margin keeps the test off the floating-point knife
-        # edge while still exercising the boundary behaviour.
-        duration_sec = (
+        sched = _sched()
+
+        def _count(duration_sec):
+            seq = _make_nirda_seq(duration_sec=duration_sec, **_NIRDA_KWARGS)
+            out = sched._update_NIRDA_integrations(
+                seq, seq.duration, overhead=_overhead()
+            )
+            return int(
+                out.get_payload_parameter(
+                    "AcquireInfCamImages", "SC_Integrations"
+                )
+            )
+
+        # Small positive margins keep both cases off the floating-point edge.
+        one = _count(first_integration_time + 1e-3)
+        two = _count(
             first_integration_time + other_integration_time + 1e-3
         )
-
-        seq = _make_nirda_seq(duration_sec=duration_sec, **_NIRDA_KWARGS)
-        sched = _sched()
-        seq_out = sched._update_NIRDA_integrations(
-            seq,
-            seq.duration,
-            overhead=_overhead(),
-        )
-
-        integ = int(
-            seq_out.get_payload_parameter(
-                "AcquireInfCamImages", "SC_Integrations"
-            )
-        )
-        assert integ == 2
+        assert two == one + 1
 
 
 # ---------------------------------------------------------------------------
@@ -689,23 +693,26 @@ class TestUpdatePayloadParametersSequence:
         assert integ == expected
 
     def test_nirda_second_integration_fits_at_boundary_via_wrapper(self):
-        """Wrapper fits the second integration just past first + other."""
+        """Wrapper adds exactly one integration for one more ``other`` window."""
         nd = _nirda_from_kwargs(**_NIRDA_KWARGS)
         first_integration_time = nd.first_integration_time.to(u.s).value
         other_integration_time = nd.other_integration_time.to(u.s).value
-        duration_sec = (
+        sched = _sched_with_overhead()
+
+        def _count(duration_sec):
+            seq = _make_nirda_seq(duration_sec=duration_sec, **_NIRDA_KWARGS)
+            out = sched._update_payload_parameters_sequence(seq)
+            return int(
+                out.get_payload_parameter(
+                    "AcquireInfCamImages", "SC_Integrations"
+                )
+            )
+
+        one = _count(first_integration_time + 1e-3)
+        two = _count(
             first_integration_time + other_integration_time + 1e-3
         )
-
-        seq = _make_nirda_seq(duration_sec=duration_sec, **_NIRDA_KWARGS)
-        sched = _sched_with_overhead()
-        seq_out = sched._update_payload_parameters_sequence(seq)
-        integ = int(
-            seq_out.get_payload_parameter(
-                "AcquireInfCamImages", "SC_Integrations"
-            )
-        )
-        assert integ == 2
+        assert two == one + 1
 
     def test_nirda_overhead_exceeds_duration_yields_zero_integrations(self):
         """Sequence shorter than NIRDA overhead budget → 0 integrations (via wrapper).
@@ -1186,3 +1193,87 @@ class TestScheduleProcessorOverheadValidation:
                     "L2",
                     nirda_pre_sequence_overhead=258,  # bare int, no units
                 )
+
+
+# ---------------------------------------------------------------------------
+# Sequential ID renumbering
+# ---------------------------------------------------------------------------
+
+
+def _seq_with_id(seq_id):
+    """Minimal ObservationSequence carrying just an ID."""
+    start = Time("2026-06-15T12:00:00", scale="utc")
+    return ObservationSequence(
+        id=seq_id,
+        target="T",
+        priority=1,
+        start_time=start,
+        stop_time=start + TimeDelta(60, format="sec"),
+        ra=0.0,
+        dec=0.0,
+        payload_params={},
+    )
+
+
+class TestRenumberIds:
+    """_renumber_ids makes visit and observation IDs contiguous."""
+
+    def _cal(self):
+        return ScienceCalendar(
+            metadata={},
+            visits=[
+                Visit(id="0007", sequences=[
+                    _seq_with_id("050"), _seq_with_id("099")
+                ]),
+                Visit(id="0003", sequences=[_seq_with_id("012")]),
+                Visit(id="ABC", sequences=[
+                    _seq_with_id("x"), _seq_with_id("y"), _seq_with_id("z")
+                ]),
+            ],
+        )
+
+    def test_visit_ids_renumbered_from_one(self):
+        """Visit IDs become 0001, 0002, ... in order."""
+        sched = ScheduleProcessor.__new__(ScheduleProcessor)
+        cal = self._cal()
+        sched._renumber_ids(cal)
+        assert [v.id for v in cal.visits] == ["0001", "0002", "0003"]
+
+    def test_observation_ids_renumbered_per_visit(self):
+        """Each visit's observation IDs restart at 001 and increment."""
+        sched = ScheduleProcessor.__new__(ScheduleProcessor)
+        cal = self._cal()
+        sched._renumber_ids(cal)
+        assert [s.id for s in cal.visits[0].sequences] == ["001", "002"]
+        assert [s.id for s in cal.visits[1].sequences] == ["001"]
+        assert [s.id for s in cal.visits[2].sequences] == [
+            "001", "002", "003"
+        ]
+
+    def test_already_sequential_is_noop(self):
+        """Correctly numbered IDs are left unchanged."""
+        sched = ScheduleProcessor.__new__(ScheduleProcessor)
+        cal = ScienceCalendar(
+            metadata={},
+            visits=[
+                Visit(id="0001", sequences=[_seq_with_id("001")]),
+                Visit(id="0002", sequences=[
+                    _seq_with_id("001"), _seq_with_id("002")
+                ]),
+            ],
+        )
+        sched._renumber_ids(cal)
+        assert [v.id for v in cal.visits] == ["0001", "0002"]
+        assert [s.id for s in cal.visits[1].sequences] == ["001", "002"]
+
+    def test_widths_are_zero_padded(self):
+        """Visit IDs use 4 digits and observation IDs use 3 digits."""
+        sched = ScheduleProcessor.__new__(ScheduleProcessor)
+        cal = self._cal()
+        sched._renumber_ids(cal)
+        assert all(len(v.id) == 4 for v in cal.visits)
+        assert all(
+            len(s.id) == 3
+            for v in cal.visits
+            for s in v.sequences
+        )

--- a/tests/test_integration_counts.py
+++ b/tests/test_integration_counts.py
@@ -890,6 +890,99 @@ class TestVisdaParameterOverride:
         )
 
 
+class TestParameterOverrideValues:
+    """Dict-form overrides force explicit values (None -> class default)."""
+
+    def test_nirda_explicit_value_written(self):
+        defaults = NirdaData()
+        seq = _make_nirda_seq(
+            duration_sec=1800,
+            sc_drop1=5,
+            sc_drop3=7,
+            **{k: v for k, v in _NIRDA_KWARGS.items() if k not in
+               ("sc_drop1", "sc_drop3")},
+        )
+        sched = _sched()
+        out = sched._update_NIRDA_integrations(
+            seq,
+            seq.duration,
+            overhead=_overhead(),
+            # drop_frames_1 -> explicit 2; drop_frames_3 -> class default.
+            override_fields={"drop_frames_1": 2, "drop_frames_3": None},
+        )
+        drop1 = int(
+            out.get_payload_parameter("AcquireInfCamImages", "SC_DropFrames1")
+        )
+        drop3 = int(
+            out.get_payload_parameter("AcquireInfCamImages", "SC_DropFrames3")
+        )
+        assert drop1 == 2
+        assert drop3 == defaults.drop_frames_3
+
+    def test_nirda_explicit_reset_changes_count(self):
+        """An explicit reset_frames_1 value drives SC_Integrations."""
+        seq_default = _make_nirda_seq(
+            duration_sec=1800, **{**_NIRDA_KWARGS, "sc_resets1": 1}
+        )
+        seq_big = seq_default.copy()
+        sched = _sched()
+        n_small = int(
+            sched._update_NIRDA_integrations(
+                seq_default, seq_default.duration, overhead=_overhead(),
+                override_fields={"reset_frames_1": 1},
+            ).get_payload_parameter(
+                "AcquireInfCamImages", "SC_Integrations"
+            )
+        )
+        n_big = int(
+            sched._update_NIRDA_integrations(
+                seq_big, seq_big.duration, overhead=_overhead(),
+                override_fields={"reset_frames_1": 5000},
+            ).get_payload_parameter(
+                "AcquireInfCamImages", "SC_Integrations"
+            )
+        )
+        # A much larger first-integration reset count fits fewer integrations.
+        assert n_big <= n_small
+
+    def test_visda_explicit_value_written(self):
+        seq = _make_vda_seq(
+            duration_sec=1800, exposure_us=500_000, frames_per_coadd=3
+        )
+        sched = _sched()
+        out = sched._update_VDA_integrations(
+            seq,
+            seq.duration,
+            overhead=_overhead(),
+            override_fields={"frames_per_coadd": 7},
+        )
+        fpc = int(
+            out.get_payload_parameter(
+                "AcquireVisCamScienceData", "FramesPerCoadd"
+            )
+        )
+        assert fpc == 7
+
+    def test_none_value_uses_default(self):
+        defaults = VisdaData()
+        seq = _make_vda_seq(
+            duration_sec=1800, exposure_us=500_000, frames_per_coadd=3
+        )
+        sched = _sched()
+        out = sched._update_VDA_integrations(
+            seq,
+            seq.duration,
+            overhead=_overhead(),
+            override_fields={"frames_per_coadd": None},
+        )
+        fpc = int(
+            out.get_payload_parameter(
+                "AcquireVisCamScienceData", "FramesPerCoadd"
+            )
+        )
+        assert fpc == defaults.frames_per_coadd
+
+
 class TestOverrideRoutingByPriority:
     """The wrapper applies overrides only to matching priorities."""
 

--- a/tests/test_integration_counts.py
+++ b/tests/test_integration_counts.py
@@ -1,6 +1,7 @@
 # Standard library
 import copy
 import unittest.mock as mock
+import warnings
 import xml.etree.ElementTree as ET
 
 # Third-party
@@ -944,6 +945,133 @@ class TestOverrideRoutingByPriority:
             proc = ScheduleProcessor("L1", "L2")
         assert proc._override_nirda_parameters == {}
         assert proc._override_visda_parameters == {}
+
+
+# ---------------------------------------------------------------------------
+# Data-volume limit warnings
+# ---------------------------------------------------------------------------
+
+
+def _sched_with_limits(max_uncompressed, max_compressed):
+    """Bare ScheduleProcessor carrying only the data-volume limits."""
+    sched = ScheduleProcessor.__new__(ScheduleProcessor)
+    sched.max_file_size_uncompressed = max_uncompressed
+    sched.max_file_size_compressed = max_compressed
+    return sched
+
+
+class TestDataSizeWarnings:
+    """The scheduler warns when computed data exceeds the size limits."""
+
+    def test_vda_oversize_raises_warning(self):
+        """A VISDA sequence over the uncompressed limit warns."""
+        # 1800 s at 0.1 s/frame -> 18000 frames; default ROI gives a large
+        # data volume that exceeds 830 MB uncompressed.
+        seq = _make_vda_seq(
+            duration_sec=1800,
+            exposure_us=100_000,
+            frames_per_coadd=1,
+        )
+        sched = _sched_with_limits(
+            830.0 * 1000 * 1000 * u.byte,
+            255.0 * 1000 * 1000 * u.byte,
+        )
+        with pytest.warns(UserWarning, match="exceeds"):
+            sched._update_VDA_integrations(
+                seq,
+                seq.duration,
+                pre_sequence_overhead=0 * u.s,
+                post_sequence_overhead=0 * u.s,
+            )
+
+    def test_vda_within_limits_no_warning(self):
+        """A small VISDA sequence under the limits must not warn."""
+        seq = _make_vda_seq(
+            duration_sec=60,
+            exposure_us=1_000_000,
+            frames_per_coadd=1,
+        )
+        sched = _sched_with_limits(
+            830.0 * 1000 * 1000 * u.byte,
+            255.0 * 1000 * 1000 * u.byte,
+        )
+        with warnings.catch_warnings():
+            warnings.simplefilter("error")
+            sched._update_VDA_integrations(
+                seq,
+                seq.duration,
+                pre_sequence_overhead=0 * u.s,
+                post_sequence_overhead=0 * u.s,
+            )
+
+    def test_nirda_oversize_raises_warning(self):
+        """A NIRDA sequence over the uncompressed limit warns."""
+        # Many groups + single read frame + long window pack many
+        # integrations' worth of saved frames into the window, inflating the
+        # data volume past the limit.
+        seq = _make_nirda_seq(
+            duration_sec=5000,
+            roi_x=200,
+            roi_y=200,
+            sc_resets1=1,
+            sc_resets2=1,
+            sc_drop1=0,
+            sc_drop2=0,
+            sc_drop3=0,
+            sc_read=1,
+            sc_groups=20,
+        )
+        sched = _sched_with_limits(
+            830.0 * 1000 * 1000 * u.byte,
+            255.0 * 1000 * 1000 * u.byte,
+        )
+        with pytest.warns(UserWarning, match="exceeds"):
+            sched._update_NIRDA_integrations(
+                seq,
+                seq.duration,
+                pre_sequence_overhead=0 * u.s,
+                post_sequence_overhead=0 * u.s,
+            )
+
+    def test_no_limits_attribute_no_warning(self):
+        """A bare processor without limits set must not warn (or crash)."""
+        seq = _make_vda_seq(
+            duration_sec=1800,
+            exposure_us=100_000,
+            frames_per_coadd=1,
+        )
+        sched = ScheduleProcessor.__new__(ScheduleProcessor)
+        with warnings.catch_warnings():
+            warnings.simplefilter("error")
+            sched._update_VDA_integrations(
+                seq,
+                seq.duration,
+                pre_sequence_overhead=0 * u.s,
+                post_sequence_overhead=0 * u.s,
+            )
+
+    def test_limits_stored_with_defaults(self):
+        """Constructor stores the default data-volume limits."""
+        with mock.patch("shortschedule.scheduler.Visibility"):
+            proc = ScheduleProcessor("L1", "L2")
+        assert proc.max_file_size_uncompressed.to(u.byte).value == (
+            830.0 * 1000 * 1000
+        )
+        assert proc.max_file_size_compressed.to(u.byte).value == (
+            255.0 * 1000 * 1000
+        )
+
+    def test_limits_overridable(self):
+        """Constructor accepts custom data-volume limits."""
+        with mock.patch("shortschedule.scheduler.Visibility"):
+            proc = ScheduleProcessor(
+                "L1",
+                "L2",
+                max_file_size_uncompressed=1.0 * u.byte,
+                max_file_size_compressed=2.0 * u.byte,
+            )
+        assert proc.max_file_size_uncompressed == 1.0 * u.byte
+        assert proc.max_file_size_compressed == 2.0 * u.byte
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_integration_counts.py
+++ b/tests/test_integration_counts.py
@@ -11,10 +11,18 @@ from astropy.time import Time, TimeDelta
 
 # First-party/Local
 from shortschedule.models import ObservationSequence
+from shortschedule.nirda import NirdaData
+from shortschedule.overhead import OverheadTiming
 from shortschedule.scheduler import ScheduleProcessor
+from shortschedule.visda import VisdaData
 
 # ---------------------------------------------------------------------------
 # Helpers
+#
+# Sequences are built from the NirdaData/VisdaData classes: a data object is
+# constructed with the desired configuration, then its payload XML is emitted
+# from the class's CONFIG_SPEC. This keeps the tests in lock-step with the
+# detector models the scheduler uses.
 # ---------------------------------------------------------------------------
 
 
@@ -23,13 +31,41 @@ def _sched():
     return ScheduleProcessor.__new__(ScheduleProcessor)
 
 
+def _payload_from_config(data_obj, extra_tags=None):
+    """Build a payload XML element for *data_obj* from its CONFIG_SPEC.
+
+    Each config field is written to its mapped XML tag using the class's
+    own ``to_xml`` converter, so the payload always matches the data model.
+    *extra_tags* adds any output-only tags (e.g. the integration count the
+    scheduler will overwrite).
+    """
+    root = ET.Element(data_obj.PAYLOAD_SECTION)
+    config = data_obj.get_config()
+    for field, (tag, _from_xml, to_xml) in data_obj.CONFIG_SPEC.items():
+        ET.SubElement(root, tag).text = to_xml(config[field])
+    for tag, text in (extra_tags or {}).items():
+        ET.SubElement(root, tag).text = text
+    return root
+
+
+def _visda_from_kwargs(exposure_us, frames_per_coadd):
+    """Build a VisdaData for the test's VDA parameters.
+
+    read_time_per_frame_s is forced to zero so a frame takes exactly the
+    exposure time, matching the scheduler's frame-count convention.
+    """
+    return VisdaData(
+        exposure_time_s=exposure_us * u.us,
+        frames_per_coadd=frames_per_coadd,
+        read_time_per_frame_s=0 * u.s,
+    )
+
+
 def _make_vda_seq(duration_sec, exposure_us, frames_per_coadd):
-    """Minimal sequence with AcquireVisCamScienceData payload."""
+    """Sequence whose AcquireVisCamScienceData payload is built from VisdaData."""
     start = Time("2026-06-15T12:00:00", scale="utc")
-    root = ET.Element("AcquireVisCamScienceData")
-    ET.SubElement(root, "ExposureTime_us").text = str(exposure_us)
-    ET.SubElement(root, "FramesPerCoadd").text = str(frames_per_coadd)
-    ET.SubElement(root, "NumTotalFramesRequested").text = "0"
+    vd = _visda_from_kwargs(exposure_us, frames_per_coadd)
+    root = _payload_from_config(vd, {"NumTotalFramesRequested": "0"})
     return ObservationSequence(
         id="vda_seq",
         target="T",
@@ -38,12 +74,25 @@ def _make_vda_seq(duration_sec, exposure_us, frames_per_coadd):
         stop_time=start + TimeDelta(duration_sec, format="sec"),
         ra=0.0,
         dec=0.0,
-        payload_params={"AcquireVisCamScienceData": root},
+        payload_params={vd.PAYLOAD_SECTION: root},
     )
 
 
-def _make_nirda_seq(
-    duration_sec,
+# Maps the legacy keyword names used by these tests to NirdaData fields.
+_NIRDA_KW_TO_FIELD = {
+    "roi_x": "roi_x_size",
+    "roi_y": "roi_y_size",
+    "sc_resets1": "reset_frames_1",
+    "sc_resets2": "reset_frames_2",
+    "sc_drop1": "drop_frames_1",
+    "sc_drop2": "drop_frames_2",
+    "sc_drop3": "drop_frames_3",
+    "sc_read": "read_frames",
+    "sc_groups": "groups",
+}
+
+
+def _nirda_from_kwargs(
     roi_x=100,
     roi_y=256,
     sc_resets1=1,
@@ -54,19 +103,27 @@ def _make_nirda_seq(
     sc_read=5,
     sc_groups=3,
 ):
-    """Minimal sequence with AcquireInfCamImages payload."""
+    """Build a NirdaData from the test's NIRDA parameters."""
+    kwargs = dict(
+        roi_x=roi_x,
+        roi_y=roi_y,
+        sc_resets1=sc_resets1,
+        sc_resets2=sc_resets2,
+        sc_drop1=sc_drop1,
+        sc_drop2=sc_drop2,
+        sc_drop3=sc_drop3,
+        sc_read=sc_read,
+        sc_groups=sc_groups,
+    )
+    fields = {_NIRDA_KW_TO_FIELD[k]: v for k, v in kwargs.items()}
+    return NirdaData(**fields)
+
+
+def _make_nirda_seq(duration_sec, **kwargs):
+    """Sequence whose AcquireInfCamImages payload is built from NirdaData."""
     start = Time("2026-06-15T12:00:00", scale="utc")
-    root = ET.Element("AcquireInfCamImages")
-    ET.SubElement(root, "ROI_SizeX").text = str(roi_x)
-    ET.SubElement(root, "ROI_SizeY").text = str(roi_y)
-    ET.SubElement(root, "SC_Resets1").text = str(sc_resets1)
-    ET.SubElement(root, "SC_Resets2").text = str(sc_resets2)
-    ET.SubElement(root, "SC_DropFrames1").text = str(sc_drop1)
-    ET.SubElement(root, "SC_DropFrames2").text = str(sc_drop2)
-    ET.SubElement(root, "SC_DropFrames3").text = str(sc_drop3)
-    ET.SubElement(root, "SC_ReadFrames").text = str(sc_read)
-    ET.SubElement(root, "SC_Groups").text = str(sc_groups)
-    ET.SubElement(root, "SC_Integrations").text = "0"
+    nd = _nirda_from_kwargs(**kwargs)
+    root = _payload_from_config(nd, {"SC_Integrations": "0"})
     return ObservationSequence(
         id="nirda_seq",
         target="T",
@@ -75,8 +132,41 @@ def _make_nirda_seq(
         stop_time=start + TimeDelta(duration_sec, format="sec"),
         ra=0.0,
         dec=0.0,
-        payload_params={"AcquireInfCamImages": root},
+        payload_params={nd.PAYLOAD_SECTION: root},
     )
+
+
+def _nirda_overhead(pre_sec=0.0, post_sec=0.0):
+    """OverheadTiming with the given NIRDA pre/post overheads (seconds)."""
+    return OverheadTiming(
+        nirda_pre_overhead_time=pre_sec * u.s,
+        nirda_post_overhead_time=post_sec * u.s,
+    )
+
+
+def _visda_overhead(pre_sec=0.0, post_sec=0.0):
+    """OverheadTiming with the given VISDA pre/post overheads (seconds)."""
+    return OverheadTiming(
+        visda_pre_overhead_time=pre_sec * u.s,
+        visda_post_overhead_time=post_sec * u.s,
+    )
+
+
+def _expected_vda_frames(
+    duration_sec,
+    *,
+    exposure_us,
+    frames_per_coadd,
+    pre_sequence_overhead_sec=0,
+    post_sequence_overhead_sec=0,
+):
+    """Expected NumTotalFramesRequested, computed via VisdaData."""
+    vd = _visda_from_kwargs(exposure_us, frames_per_coadd)
+    frames, _, _ = vd.solve_integrations(
+        duration_sec * u.s,
+        _visda_overhead(pre_sequence_overhead_sec, post_sequence_overhead_sec),
+    )
+    return int(frames)
 
 
 # ---------------------------------------------------------------------------
@@ -271,37 +361,15 @@ def _expected_nirda_integrations(
     post_sequence_overhead_sec=0,
     **kwargs,
 ):
-    """Match the scheduler's first-integration and later-integration math."""
-    roi_x = kwargs["roi_x"]
-    roi_y = kwargs["roi_y"]
-    sc_resets1 = kwargs["sc_resets1"]
-    sc_resets2 = kwargs["sc_resets2"]
-    sc_drop1 = kwargs["sc_drop1"]
-    sc_drop2 = kwargs["sc_drop2"]
-    sc_drop3 = kwargs["sc_drop3"]
-    sc_read = kwargs["sc_read"]
-    sc_groups = kwargs["sc_groups"]
-
-    frame_time = (roi_x + 12) * (roi_y + 2) * 1e-5
-    num_frames_base = (
-        sc_drop1 + (sc_groups - 1) * (sc_read + sc_drop2) + sc_read + sc_drop3
+    """Expected SC_Integrations, computed via NirdaData."""
+    nd = _nirda_from_kwargs(**kwargs)
+    integrations, _, _ = nd.solve_integrations(
+        duration_sec * u.s,
+        _nirda_overhead(
+            pre_sequence_overhead_sec, post_sequence_overhead_sec
+        ),
     )
-    first_integration_time = (num_frames_base + sc_resets1) * frame_time
-    other_integration_time = (num_frames_base + sc_resets2) * frame_time
-
-    effective_duration = (
-        duration_sec - pre_sequence_overhead_sec - post_sequence_overhead_sec
-    )
-    if effective_duration <= 0 or first_integration_time > effective_duration:
-        return 0
-
-    integrations = 1
-    effective_duration -= first_integration_time
-    if effective_duration > other_integration_time:
-        integrations += int(
-            np.floor(effective_duration / other_integration_time)
-        )
-    return integrations
+    return int(integrations)
 
 
 class TestUpdateNIRDAIntegrations:
@@ -353,11 +421,7 @@ class TestUpdateNIRDAIntegrations:
                 "AcquireInfCamImages", "SC_Integrations"
             )
         )
-        # integration_time = 16 * 0.28896 = 4.62336 s → floor(1800/4.62336) = 389
-        frame_time = (100 + 12) * (256 + 2) * 1e-5
-        num_frames_total = 1 + 0 + 1 * (0 + 2 * (5 + 0) + 5 + 0)
-        integration_time = num_frames_total * frame_time
-        expected = int(np.floor(1800 / integration_time))
+        expected = _expected_nirda_integrations(1800, **_NIRDA_KWARGS)
         assert integ == expected
 
     def test_exact_integration_count_with_default_overhead(self):
@@ -429,17 +493,21 @@ class TestUpdateNIRDAIntegrations:
         )
         assert integ == expected
 
-    def test_exact_boundary_for_second_integration_does_not_add_it(self):
-        """An exact fit for the second integration keeps the count at one."""
-        frame_time = (100 + 12) * (256 + 2) * 1e-5
-        num_frames_base = 0 + 2 * (5 + 0) + 5 + 0
-        first_integration_time = (
-            num_frames_base + _NIRDA_KWARGS["sc_resets1"]
-        ) * frame_time
-        other_integration_time = (
-            num_frames_base + _NIRDA_KWARGS["sc_resets2"]
-        ) * frame_time
-        duration_sec = first_integration_time + other_integration_time
+    def test_second_integration_fits_at_boundary(self):
+        """A window of first + other (plus a hair) fits two integrations.
+
+        NirdaData.solve_integrations fits the second integration as soon as
+        the remaining time reaches the "other" integration time, so a window
+        just past first + other yields two integrations.
+        """
+        nd = _nirda_from_kwargs(**_NIRDA_KWARGS)
+        first_integration_time = nd.first_integration_time.to(u.s).value
+        other_integration_time = nd.other_integration_time.to(u.s).value
+        # Small positive margin keeps the test off the floating-point knife
+        # edge while still exercising the boundary behaviour.
+        duration_sec = (
+            first_integration_time + other_integration_time + 1e-3
+        )
 
         seq = _make_nirda_seq(duration_sec=duration_sec, **_NIRDA_KWARGS)
         sched = _sched()
@@ -455,7 +523,7 @@ class TestUpdateNIRDAIntegrations:
                 "AcquireInfCamImages", "SC_Integrations"
             )
         )
-        assert integ == 1
+        assert integ == 2
 
 
 # ---------------------------------------------------------------------------
@@ -469,12 +537,14 @@ def _sched_with_overhead(
     nirda_pre=0 * u.s,
     nirda_post=0 * u.s,
 ):
-    """ScheduleProcessor instance with only the overhead attributes set."""
+    """ScheduleProcessor instance whose only state is its OverheadTiming."""
     sched = ScheduleProcessor.__new__(ScheduleProcessor)
-    sched.vda_pre_sequence_overhead = vda_pre
-    sched.vda_post_sequence_overhead = vda_post
-    sched.nirda_pre_sequence_overhead = nirda_pre
-    sched.nirda_post_sequence_overhead = nirda_post
+    sched.overhead = OverheadTiming(
+        visda_pre_overhead_time=vda_pre,
+        visda_post_overhead_time=vda_post,
+        nirda_pre_overhead_time=nirda_pre,
+        nirda_post_overhead_time=nirda_post,
+    )
     return sched
 
 
@@ -617,17 +687,14 @@ class TestUpdatePayloadParametersSequence:
         )
         assert integ == expected
 
-    def test_nirda_exact_boundary_for_second_integration_via_wrapper(self):
-        """Wrapper preserves the exact-fit boundary for later integrations."""
-        frame_time = (100 + 12) * (256 + 2) * 1e-5
-        num_frames_base = 0 + 2 * (5 + 0) + 5 + 0
-        first_integration_time = (
-            num_frames_base + _NIRDA_KWARGS["sc_resets1"]
-        ) * frame_time
-        other_integration_time = (
-            num_frames_base + _NIRDA_KWARGS["sc_resets2"]
-        ) * frame_time
-        duration_sec = first_integration_time + other_integration_time
+    def test_nirda_second_integration_fits_at_boundary_via_wrapper(self):
+        """Wrapper fits the second integration just past first + other."""
+        nd = _nirda_from_kwargs(**_NIRDA_KWARGS)
+        first_integration_time = nd.first_integration_time.to(u.s).value
+        other_integration_time = nd.other_integration_time.to(u.s).value
+        duration_sec = (
+            first_integration_time + other_integration_time + 1e-3
+        )
 
         seq = _make_nirda_seq(duration_sec=duration_sec, **_NIRDA_KWARGS)
         sched = _sched_with_overhead()
@@ -637,7 +704,7 @@ class TestUpdatePayloadParametersSequence:
                 "AcquireInfCamImages", "SC_Integrations"
             )
         )
-        assert integ == 1
+        assert integ == 2
 
     def test_nirda_overhead_exceeds_duration_yields_zero_integrations(self):
         """Sequence shorter than NIRDA overhead budget → 0 integrations (via wrapper).
@@ -674,6 +741,212 @@ class TestUpdatePayloadParametersSequence:
 
 
 # ---------------------------------------------------------------------------
+# Per-priority parameter overrides
+# ---------------------------------------------------------------------------
+
+
+class TestNirdaParameterOverride:
+    """override_fields replaces observation values with NirdaData defaults."""
+
+    def test_overridden_fields_written_back_as_defaults(self):
+        """Listed fields are replaced by class defaults and written to XML."""
+        defaults = NirdaData()
+        # Build a sequence whose drop frames differ from the class defaults.
+        seq = _make_nirda_seq(
+            duration_sec=1800,
+            sc_drop1=5,
+            sc_drop3=7,
+            **{k: v for k, v in _NIRDA_KWARGS.items() if k not in
+               ("sc_drop1", "sc_drop3")},
+        )
+        sched = _sched()
+        seq_out = sched._update_NIRDA_integrations(
+            seq,
+            seq.duration,
+            pre_sequence_overhead=0 * u.s,
+            post_sequence_overhead=0 * u.s,
+            override_fields=["drop_frames_1", "drop_frames_3"],
+        )
+
+        drop1 = seq_out.get_payload_parameter(
+            "AcquireInfCamImages", "SC_DropFrames1"
+        )
+        drop3 = seq_out.get_payload_parameter(
+            "AcquireInfCamImages", "SC_DropFrames3"
+        )
+        assert int(drop1) == defaults.drop_frames_1
+        assert int(drop3) == defaults.drop_frames_3
+
+    def test_non_overridden_fields_untouched(self):
+        """Fields not listed keep the observation's original values."""
+        seq = _make_nirda_seq(
+            duration_sec=1800,
+            sc_drop2=9,
+            **{k: v for k, v in _NIRDA_KWARGS.items() if k != "sc_drop2"},
+        )
+        sched = _sched()
+        seq_out = sched._update_NIRDA_integrations(
+            seq,
+            seq.duration,
+            pre_sequence_overhead=0 * u.s,
+            post_sequence_overhead=0 * u.s,
+            override_fields=["drop_frames_1"],
+        )
+        drop2 = seq_out.get_payload_parameter(
+            "AcquireInfCamImages", "SC_DropFrames2"
+        )
+        assert int(drop2) == 9
+
+    def test_override_changes_integration_count(self):
+        """Overriding reset frames changes the computed SC_Integrations."""
+        # Large SC_Resets1 in the observation lengthens the first integration;
+        # overriding reset_frames_1 with the (smaller) default should let more
+        # integrations fit.
+        seq_a = _make_nirda_seq(
+            duration_sec=1800,
+            **{**_NIRDA_KWARGS, "sc_resets1": 500},
+        )
+        seq_b = seq_a.copy()
+        sched = _sched()
+
+        out_no = sched._update_NIRDA_integrations(
+            seq_a,
+            seq_a.duration,
+            pre_sequence_overhead=0 * u.s,
+            post_sequence_overhead=0 * u.s,
+        )
+        out_override = sched._update_NIRDA_integrations(
+            seq_b,
+            seq_b.duration,
+            pre_sequence_overhead=0 * u.s,
+            post_sequence_overhead=0 * u.s,
+            override_fields=["reset_frames_1"],
+        )
+        integ_no = int(
+            out_no.get_payload_parameter(
+                "AcquireInfCamImages", "SC_Integrations"
+            )
+        )
+        integ_override = int(
+            out_override.get_payload_parameter(
+                "AcquireInfCamImages", "SC_Integrations"
+            )
+        )
+        # Default reset_frames_1 (50) < 500, so the first integration is
+        # shorter and the count should not decrease.
+        assert integ_override >= integ_no
+
+
+class TestVisdaParameterOverride:
+    """override_fields replaces observation values with VisdaData defaults."""
+
+    def test_overridden_field_written_back_as_default(self):
+        defaults = VisdaData()
+        seq = _make_vda_seq(
+            duration_sec=1800,
+            exposure_us=500_000,
+            frames_per_coadd=3,
+        )
+        sched = _sched()
+        seq_out = sched._update_VDA_integrations(
+            seq,
+            seq.duration,
+            pre_sequence_overhead=0 * u.s,
+            post_sequence_overhead=0 * u.s,
+            override_fields=["frames_per_coadd"],
+        )
+        fpc = seq_out.get_payload_parameter(
+            "AcquireVisCamScienceData", "FramesPerCoadd"
+        )
+        assert int(fpc) == defaults.frames_per_coadd
+        # Exposure (not overridden) is unchanged.
+        exposure = seq_out.get_payload_parameter(
+            "AcquireVisCamScienceData", "ExposureTime_us"
+        )
+        assert int(exposure) == 500_000
+
+    def test_exposure_override_written_in_microseconds(self):
+        defaults = VisdaData()
+        seq = _make_vda_seq(
+            duration_sec=1800,
+            exposure_us=500_000,
+            frames_per_coadd=1,
+        )
+        sched = _sched()
+        seq_out = sched._update_VDA_integrations(
+            seq,
+            seq.duration,
+            pre_sequence_overhead=0 * u.s,
+            post_sequence_overhead=0 * u.s,
+            override_fields=["exposure_time_s"],
+        )
+        exposure = seq_out.get_payload_parameter(
+            "AcquireVisCamScienceData", "ExposureTime_us"
+        )
+        assert int(exposure) == int(
+            defaults.exposure_time_s.to(u.us).value
+        )
+
+
+class TestOverrideRoutingByPriority:
+    """The wrapper applies overrides only to matching priorities."""
+
+    def _make_nirda_seq_priority(self, priority):
+        seq = _make_nirda_seq(
+            duration_sec=1800,
+            sc_drop1=5,
+            **{k: v for k, v in _NIRDA_KWARGS.items() if k != "sc_drop1"},
+        )
+        seq.priority = priority
+        return seq
+
+    def test_matching_priority_is_overridden(self):
+        defaults = NirdaData()
+        sched = _sched_with_overhead()
+        sched._override_nirda_parameters = {0: ["drop_frames_1"]}
+        sched._override_visda_parameters = {}
+
+        seq = self._make_nirda_seq_priority(0)
+        out = sched._update_payload_parameters_sequence(seq)
+        drop1 = out.get_payload_parameter(
+            "AcquireInfCamImages", "SC_DropFrames1"
+        )
+        assert int(drop1) == defaults.drop_frames_1
+
+    def test_non_matching_priority_not_overridden(self):
+        sched = _sched_with_overhead()
+        sched._override_nirda_parameters = {0: ["drop_frames_1"]}
+        sched._override_visda_parameters = {}
+
+        seq = self._make_nirda_seq_priority(2)
+        out = sched._update_payload_parameters_sequence(seq)
+        drop1 = out.get_payload_parameter(
+            "AcquireInfCamImages", "SC_DropFrames1"
+        )
+        # Priority 2 not in override map -> observation value (5) preserved.
+        assert int(drop1) == 5
+
+    def test_overrides_accepted_and_stored_via_constructor(self):
+        """override_*_parameters are constructor args stored on the instance."""
+        with mock.patch("shortschedule.scheduler.Visibility"):
+            proc = ScheduleProcessor(
+                "L1",
+                "L2",
+                override_nirda_parameters={0: ["drop_frames_1"]},
+                override_visda_parameters={1: ["frames_per_coadd"]},
+            )
+        assert proc._override_nirda_parameters == {0: ["drop_frames_1"]}
+        assert proc._override_visda_parameters == {1: ["frames_per_coadd"]}
+
+    def test_override_defaults_to_empty_when_unset(self):
+        """Omitting the override args yields empty override maps."""
+        with mock.patch("shortschedule.scheduler.Visibility"):
+            proc = ScheduleProcessor("L1", "L2")
+        assert proc._override_nirda_parameters == {}
+        assert proc._override_visda_parameters == {}
+
+
+# ---------------------------------------------------------------------------
 # ScheduleProcessor.__init__ overhead validation
 # ---------------------------------------------------------------------------
 
@@ -685,7 +958,7 @@ class TestScheduleProcessorOverheadValidation:
         """Default overhead values (Quantity with time units) are accepted."""
         with mock.patch("shortschedule.scheduler.Visibility"):
             proc = ScheduleProcessor("L1", "L2")
-        assert proc.vda_pre_sequence_overhead == 260 * u.s
+        assert proc.overhead.visda_pre_overhead_time == 260 * u.s
 
     def test_timedelta_overhead_accepted(self):
         """TimeDelta overhead values must also be accepted without error."""
@@ -695,7 +968,7 @@ class TestScheduleProcessorOverheadValidation:
                 "L2",
                 vda_pre_sequence_overhead=TimeDelta(300 * u.s),
             )
-        assert proc.vda_pre_sequence_overhead == TimeDelta(300 * u.s)
+        assert proc.overhead.visda_pre_overhead_time == TimeDelta(300 * u.s)
 
     def test_wrong_units_raises_value_error(self):
         """A Quantity with non-time units must raise ValueError."""

--- a/tests/test_integration_counts.py
+++ b/tests/test_integration_counts.py
@@ -153,6 +153,20 @@ def _visda_overhead(pre_sec=0.0, post_sec=0.0):
     )
 
 
+def _overhead(pre=0 * u.s, post=0 * u.s):
+    """OverheadTiming applying the same pre/post to both detectors.
+
+    Lets a test pass one overhead to either the VDA or NIRDA update without
+    caring which detector reads which field.
+    """
+    return OverheadTiming(
+        visda_pre_overhead_time=pre,
+        visda_post_overhead_time=post,
+        nirda_pre_overhead_time=pre,
+        nirda_post_overhead_time=post,
+    )
+
+
 def _expected_vda_frames(
     duration_sec,
     *,
@@ -190,14 +204,12 @@ class TestUpdateVDAIntegrations:
         seq_no = sched._update_VDA_integrations(
             copy.deepcopy(seq),
             duration,
-            pre_sequence_overhead=0 * u.s,
-            post_sequence_overhead=0 * u.s,
+            overhead=_overhead(),
         )
         seq_with = sched._update_VDA_integrations(
             copy.deepcopy(seq),
             duration,
-            pre_sequence_overhead=260 * u.s,
-            post_sequence_overhead=60 * u.s,
+            overhead=_overhead(260 * u.s, 60 * u.s),
         )
 
         frames_no = int(
@@ -225,8 +237,7 @@ class TestUpdateVDAIntegrations:
         seq_out = sched._update_VDA_integrations(
             seq,
             duration,
-            pre_sequence_overhead=0 * u.s,
-            post_sequence_overhead=0 * u.s,
+            overhead=_overhead(),
         )
         frames = int(
             seq_out.get_payload_parameter(
@@ -247,8 +258,7 @@ class TestUpdateVDAIntegrations:
         seq_out = sched._update_VDA_integrations(
             seq,
             duration,
-            pre_sequence_overhead=260 * u.s,
-            post_sequence_overhead=60 * u.s,
+            overhead=_overhead(260 * u.s, 60 * u.s),
         )
         frames = int(
             seq_out.get_payload_parameter(
@@ -269,8 +279,7 @@ class TestUpdateVDAIntegrations:
         seq_out = sched._update_VDA_integrations(
             seq,
             duration,
-            pre_sequence_overhead=260 * u.s,
-            post_sequence_overhead=60 * u.s,
+            overhead=_overhead(260 * u.s, 60 * u.s),
         )
         frames = int(
             seq_out.get_payload_parameter(
@@ -291,8 +300,7 @@ class TestUpdateVDAIntegrations:
         seq_out = sched._update_VDA_integrations(
             seq,
             duration,
-            pre_sequence_overhead=260 * u.s,
-            post_sequence_overhead=60 * u.s,
+            overhead=_overhead(260 * u.s, 60 * u.s),
         )
         frames = int(
             seq_out.get_payload_parameter(
@@ -315,8 +323,7 @@ class TestUpdateVDAIntegrations:
         seq_out = sched._update_VDA_integrations(
             seq,
             duration,
-            pre_sequence_overhead=100 * u.s,
-            post_sequence_overhead=50 * u.s,
+            overhead=_overhead(100 * u.s, 50 * u.s),
         )
         frames = int(
             seq_out.get_payload_parameter(
@@ -384,14 +391,12 @@ class TestUpdateNIRDAIntegrations:
         seq_no = sched._update_NIRDA_integrations(
             copy.deepcopy(seq),
             duration,
-            pre_sequence_overhead=0 * u.s,
-            post_sequence_overhead=0 * u.s,
+            overhead=_overhead(),
         )
         seq_with = sched._update_NIRDA_integrations(
             copy.deepcopy(seq),
             duration,
-            pre_sequence_overhead=258 * u.s,
-            post_sequence_overhead=60 * u.s,
+            overhead=_overhead(258 * u.s, 60 * u.s),
         )
 
         integ_no = int(
@@ -414,8 +419,7 @@ class TestUpdateNIRDAIntegrations:
         seq_out = sched._update_NIRDA_integrations(
             seq,
             duration,
-            pre_sequence_overhead=0 * u.s,
-            post_sequence_overhead=0 * u.s,
+            overhead=_overhead(),
         )
         integ = int(
             seq_out.get_payload_parameter(
@@ -433,8 +437,7 @@ class TestUpdateNIRDAIntegrations:
         seq_out = sched._update_NIRDA_integrations(
             seq,
             duration,
-            pre_sequence_overhead=258 * u.s,
-            post_sequence_overhead=60 * u.s,
+            overhead=_overhead(258 * u.s, 60 * u.s),
         )
         integ = int(
             seq_out.get_payload_parameter(
@@ -457,8 +460,7 @@ class TestUpdateNIRDAIntegrations:
         seq_out = sched._update_NIRDA_integrations(
             seq,
             duration,
-            pre_sequence_overhead=258 * u.s,
-            post_sequence_overhead=60 * u.s,
+            overhead=_overhead(258 * u.s, 60 * u.s),
         )
         integ = int(
             seq_out.get_payload_parameter(
@@ -478,8 +480,7 @@ class TestUpdateNIRDAIntegrations:
         seq_out = sched._update_NIRDA_integrations(
             seq,
             duration,
-            pre_sequence_overhead=start_oh * u.s,
-            post_sequence_overhead=end_oh * u.s,
+            overhead=_overhead(start_oh * u.s, end_oh * u.s),
         )
         integ = int(
             seq_out.get_payload_parameter(
@@ -515,8 +516,7 @@ class TestUpdateNIRDAIntegrations:
         seq_out = sched._update_NIRDA_integrations(
             seq,
             seq.duration,
-            pre_sequence_overhead=0 * u.s,
-            post_sequence_overhead=0 * u.s,
+            overhead=_overhead(),
         )
 
         integ = int(
@@ -764,8 +764,7 @@ class TestNirdaParameterOverride:
         seq_out = sched._update_NIRDA_integrations(
             seq,
             seq.duration,
-            pre_sequence_overhead=0 * u.s,
-            post_sequence_overhead=0 * u.s,
+            overhead=_overhead(),
             override_fields=["drop_frames_1", "drop_frames_3"],
         )
 
@@ -789,8 +788,7 @@ class TestNirdaParameterOverride:
         seq_out = sched._update_NIRDA_integrations(
             seq,
             seq.duration,
-            pre_sequence_overhead=0 * u.s,
-            post_sequence_overhead=0 * u.s,
+            overhead=_overhead(),
             override_fields=["drop_frames_1"],
         )
         drop2 = seq_out.get_payload_parameter(
@@ -813,14 +811,12 @@ class TestNirdaParameterOverride:
         out_no = sched._update_NIRDA_integrations(
             seq_a,
             seq_a.duration,
-            pre_sequence_overhead=0 * u.s,
-            post_sequence_overhead=0 * u.s,
+            overhead=_overhead(),
         )
         out_override = sched._update_NIRDA_integrations(
             seq_b,
             seq_b.duration,
-            pre_sequence_overhead=0 * u.s,
-            post_sequence_overhead=0 * u.s,
+            overhead=_overhead(),
             override_fields=["reset_frames_1"],
         )
         integ_no = int(
@@ -852,8 +848,7 @@ class TestVisdaParameterOverride:
         seq_out = sched._update_VDA_integrations(
             seq,
             seq.duration,
-            pre_sequence_overhead=0 * u.s,
-            post_sequence_overhead=0 * u.s,
+            overhead=_overhead(),
             override_fields=["frames_per_coadd"],
         )
         fpc = seq_out.get_payload_parameter(
@@ -877,8 +872,7 @@ class TestVisdaParameterOverride:
         seq_out = sched._update_VDA_integrations(
             seq,
             seq.duration,
-            pre_sequence_overhead=0 * u.s,
-            post_sequence_overhead=0 * u.s,
+            overhead=_overhead(),
             override_fields=["exposure_time_s"],
         )
         exposure = seq_out.get_payload_parameter(
@@ -980,8 +974,7 @@ class TestDataSizeWarnings:
             sched._update_VDA_integrations(
                 seq,
                 seq.duration,
-                pre_sequence_overhead=0 * u.s,
-                post_sequence_overhead=0 * u.s,
+                overhead=_overhead(),
             )
 
     def test_vda_within_limits_no_warning(self):
@@ -1000,8 +993,7 @@ class TestDataSizeWarnings:
             sched._update_VDA_integrations(
                 seq,
                 seq.duration,
-                pre_sequence_overhead=0 * u.s,
-                post_sequence_overhead=0 * u.s,
+                overhead=_overhead(),
             )
 
     def test_nirda_oversize_raises_warning(self):
@@ -1029,8 +1021,7 @@ class TestDataSizeWarnings:
             sched._update_NIRDA_integrations(
                 seq,
                 seq.duration,
-                pre_sequence_overhead=0 * u.s,
-                post_sequence_overhead=0 * u.s,
+                overhead=_overhead(),
             )
 
     def test_no_limits_attribute_no_warning(self):
@@ -1046,8 +1037,7 @@ class TestDataSizeWarnings:
             sched._update_VDA_integrations(
                 seq,
                 seq.duration,
-                pre_sequence_overhead=0 * u.s,
-                post_sequence_overhead=0 * u.s,
+                overhead=_overhead(),
             )
 
     def test_limits_stored_with_defaults(self):

--- a/tests/test_integration_counts.py
+++ b/tests/test_integration_counts.py
@@ -954,6 +954,83 @@ def _sched_with_limits(max_uncompressed, max_compressed):
     return sched
 
 
+class TestVitlReset1:
+    """update_nirda_reset1_for_vitl adjusts SC_Resets1 before solving."""
+
+    _KW = dict(
+        roi_x=100,
+        roi_y=256,
+        sc_resets1=1,
+        sc_resets2=1,
+        sc_drop1=0,
+        sc_drop2=0,
+        sc_drop3=0,
+        sc_read=5,
+        sc_groups=3,
+    )
+
+    def _sched(self, enabled, vitl=60.0 * u.s):
+        sched = ScheduleProcessor.__new__(ScheduleProcessor)
+        sched.update_nirda_reset1_for_vitl = enabled
+        sched.vitl_settling_time = vitl
+        return sched
+
+    def test_reset1_updated_when_enabled(self):
+        """SC_Resets1 is set to cover the VITL settling time."""
+        seq = _make_nirda_seq(duration_sec=2000, **self._KW)
+        sched = self._sched(enabled=True, vitl=60.0 * u.s)
+        out = sched._update_NIRDA_integrations(
+            seq, seq.duration, overhead=_overhead()
+        )
+        reset1 = int(
+            out.get_payload_parameter("AcquireInfCamImages", "SC_Resets1")
+        )
+        # Expected value comes from NirdaData.update_for_vitl itself.
+        expected = _nirda_from_kwargs(**self._KW)
+        expected.update_for_vitl(60.0 * u.s)
+        assert reset1 == expected.reset_frames_1
+        assert reset1 > 1  # the seq started at sc_resets1=1
+
+    def test_reset1_untouched_when_disabled(self):
+        """With the flag off, SC_Resets1 keeps the observation's value."""
+        seq = _make_nirda_seq(duration_sec=2000, **self._KW)
+        sched = self._sched(enabled=False)
+        out = sched._update_NIRDA_integrations(
+            seq, seq.duration, overhead=_overhead()
+        )
+        reset1 = int(
+            out.get_payload_parameter("AcquireInfCamImages", "SC_Resets1")
+        )
+        assert reset1 == 1
+
+    def test_longer_settling_needs_more_resets(self):
+        """A longer VITL settling time requires at least as many resets."""
+        seq_short = _make_nirda_seq(duration_sec=2000, **self._KW)
+        seq_long = _make_nirda_seq(duration_sec=2000, **self._KW)
+        r_short = int(
+            self._sched(True, 30.0 * u.s)
+            ._update_NIRDA_integrations(
+                seq_short, seq_short.duration, overhead=_overhead()
+            )
+            .get_payload_parameter("AcquireInfCamImages", "SC_Resets1")
+        )
+        r_long = int(
+            self._sched(True, 120.0 * u.s)
+            ._update_NIRDA_integrations(
+                seq_long, seq_long.duration, overhead=_overhead()
+            )
+            .get_payload_parameter("AcquireInfCamImages", "SC_Resets1")
+        )
+        assert r_long >= r_short
+
+    def test_defaults_stored_via_constructor(self):
+        """Constructor enables VITL reset adjustment with a 60 s default."""
+        with mock.patch("shortschedule.scheduler.Visibility"):
+            proc = ScheduleProcessor("L1", "L2")
+        assert proc.update_nirda_reset1_for_vitl is True
+        assert proc.vitl_settling_time == 60.0 * u.s
+
+
 class TestDataSizeWarnings:
     """The scheduler warns when computed data exceeds the size limits."""
 

--- a/tests/test_io_roundtrip.py
+++ b/tests/test_io_roundtrip.py
@@ -1,6 +1,6 @@
 # Standard library
-import os
 import xml.etree.ElementTree as ET
+from pathlib import Path
 
 # First-party/Local
 import shortschedule
@@ -9,15 +9,16 @@ from shortschedule.writer import XMLWriter
 
 
 def get_sample_calendar_path():
-    pkgdir = os.path.dirname(shortschedule.__file__)
-    return os.path.join(
-        pkgdir, "data", "Pandora_science_calendar_20251018_tsb-futz.xml"
+    return (
+        Path(shortschedule.__file__).parent
+        / "data"
+        / "Pandora_science_calendar_20251018_tsb-futz.xml"
     )
 
 
 def test_parse_sample_calendar_and_roundtrip(tmp_path):
     sample = get_sample_calendar_path()
-    assert os.path.exists(sample), f"Sample calendar not found at {sample}"
+    assert sample.exists(), f"Sample calendar not found at {sample}"
 
     cal = parse_science_calendar(sample)
     # Basic sanity checks
@@ -30,7 +31,7 @@ def test_parse_sample_calendar_and_roundtrip(tmp_path):
     out_file = tmp_path / "roundtrip.xml"
     writer = XMLWriter()
     written = writer.write_calendar(cal, str(out_file))
-    assert os.path.exists(written)
+    assert Path(written).exists()
 
     cal2 = parse_science_calendar(written)
     total_sequences2 = sum(len(v.sequences) for v in cal2.visits)

--- a/tests/test_merge_observations.py
+++ b/tests/test_merge_observations.py
@@ -1,0 +1,298 @@
+"""Tests for merging adjacent same-target observations in the scheduler.
+
+Covers ScheduleProcessor._merge_similar_observations and its integration
+into process_calendar via the merge_similar_observations kwarg:
+- Adjacent same-target sequences in a visit are merged
+- Transitive merging of three or more contiguous sequences
+- Different targets / pointings are not merged
+- Non-contiguous (gapped) sequences are not merged
+- Merges never cross visit boundaries
+- The merged sequence keeps the first sequence's identity/payload and the
+  second sequence's stop time
+- The input calendar is not mutated
+- End-to-end wiring through process_calendar
+"""
+
+# Standard library
+from pathlib import Path
+
+# Third-party
+import numpy as np
+import pytest
+from astropy import units as u
+from astropy.time import Time
+
+# First-party/Local
+from shortschedule.models import ObservationSequence, ScienceCalendar, Visit
+from shortschedule.scheduler import ScheduleProcessor
+
+# ================================================================
+# Helpers
+# ================================================================
+
+T0 = Time("2026-01-01T00:00:00", scale="utc")
+
+
+def _make_seq(sid, target, start_min, duration_min, ra=10.0, dec=20.0):
+    """Create an ObservationSequence starting *start_min* after T0."""
+    start = T0 + start_min * u.min
+    stop = start + duration_min * u.min
+    return ObservationSequence(
+        id=sid,
+        target=target,
+        priority=1,
+        start_time=start,
+        stop_time=stop,
+        ra=ra,
+        dec=dec,
+        payload_params={},
+    )
+
+
+def _make_calendar(sequences, visit_id="v1"):
+    """Wrap a list of sequences into a single-visit calendar."""
+    visit = Visit(id=visit_id, sequences=sequences)
+    return ScienceCalendar(metadata={}, visits=[visit])
+
+
+def _bare_processor():
+    """A ScheduleProcessor with no Visibility; merge needs no other state."""
+    return ScheduleProcessor.__new__(ScheduleProcessor)
+
+
+def _seq_by_id(visit, sid):
+    return next((s for s in visit.sequences if s.id == sid), None)
+
+
+# ================================================================
+# Tests: _merge_similar_observations
+# ================================================================
+
+
+class TestMergeSimilarObservations:
+    """Unit tests for ScheduleProcessor._merge_similar_observations."""
+
+    def test_adjacent_same_target_merged(self):
+        """Two back-to-back same-target sequences collapse into one."""
+        proc = _bare_processor()
+        seqA = _make_seq("s1", "TargetA", start_min=0, duration_min=20)
+        seqB = _make_seq("s2", "TargetA", start_min=20, duration_min=30)
+        cal = _make_calendar([seqA, seqB])
+
+        result = proc._merge_similar_observations(cal)
+
+        seqs = result.visits[0].sequences
+        assert len(seqs) == 1
+        merged = seqs[0]
+        # Keeps the first sequence's identity, spans both durations.
+        assert merged.id == "s1"
+        assert merged.start_time == seqA.start_time
+        assert merged.stop_time == seqB.stop_time
+
+    def test_three_contiguous_merge_transitively(self):
+        """A run of three contiguous sequences collapses to one."""
+        proc = _bare_processor()
+        seqs_in = [
+            _make_seq("s1", "TargetA", start_min=0, duration_min=10),
+            _make_seq("s2", "TargetA", start_min=10, duration_min=10),
+            _make_seq("s3", "TargetA", start_min=20, duration_min=10),
+        ]
+        cal = _make_calendar(seqs_in)
+
+        result = proc._merge_similar_observations(cal)
+
+        seqs = result.visits[0].sequences
+        assert len(seqs) == 1
+        assert seqs[0].id == "s1"
+        assert seqs[0].stop_time == seqs_in[-1].stop_time
+
+    def test_different_targets_not_merged(self):
+        """Adjacent sequences with different targets are left alone."""
+        proc = _bare_processor()
+        seqA = _make_seq("s1", "TargetA", start_min=0, duration_min=20)
+        seqB = _make_seq("s2", "TargetB", start_min=20, duration_min=20)
+        cal = _make_calendar([seqA, seqB])
+
+        result = proc._merge_similar_observations(cal)
+
+        assert len(result.visits[0].sequences) == 2
+
+    def test_same_target_different_pointing_not_merged(self):
+        """Same target name but different RA/Dec is not merged."""
+        proc = _bare_processor()
+        seqA = _make_seq(
+            "s1", "TargetA", start_min=0, duration_min=20, ra=10.0
+        )
+        seqB = _make_seq(
+            "s2", "TargetA", start_min=20, duration_min=20, ra=42.0
+        )
+        cal = _make_calendar([seqA, seqB])
+
+        result = proc._merge_similar_observations(cal)
+
+        assert len(result.visits[0].sequences) == 2
+
+    def test_gapped_sequences_not_merged(self):
+        """A time gap between same-target sequences prevents merging."""
+        proc = _bare_processor()
+        seqA = _make_seq("s1", "TargetA", start_min=0, duration_min=20)
+        # Starts 10 min after seqA stops.
+        seqB = _make_seq("s2", "TargetA", start_min=30, duration_min=20)
+        cal = _make_calendar([seqA, seqB])
+
+        result = proc._merge_similar_observations(cal)
+
+        assert len(result.visits[0].sequences) == 2
+
+    def test_no_merge_across_visits(self):
+        """Identical adjacent sequences in different visits stay separate."""
+        proc = _bare_processor()
+        seqA = _make_seq("s1", "TargetA", start_min=0, duration_min=20)
+        seqB = _make_seq("s1", "TargetA", start_min=20, duration_min=20)
+        cal = ScienceCalendar(
+            metadata={},
+            visits=[
+                Visit(id="v1", sequences=[seqA]),
+                Visit(id="v2", sequences=[seqB]),
+            ],
+        )
+
+        result = proc._merge_similar_observations(cal)
+
+        assert len(result.visits) == 2
+        assert len(result.visits[0].sequences) == 1
+        assert len(result.visits[1].sequences) == 1
+
+    def test_merge_mixed_run(self):
+        """Only the contiguous same-target prefix merges; rest preserved."""
+        proc = _bare_processor()
+        seqs_in = [
+            _make_seq("s1", "TargetA", start_min=0, duration_min=10),
+            _make_seq("s2", "TargetA", start_min=10, duration_min=10),
+            _make_seq("s3", "TargetB", start_min=20, duration_min=10),
+            _make_seq("s4", "TargetB", start_min=30, duration_min=10),
+        ]
+        cal = _make_calendar(seqs_in)
+
+        result = proc._merge_similar_observations(cal)
+
+        seqs = result.visits[0].sequences
+        assert [s.id for s in seqs] == ["s1", "s3"]
+        assert seqs[0].stop_time == seqs_in[1].stop_time  # s1+s2
+        assert seqs[1].stop_time == seqs_in[3].stop_time  # s3+s4
+
+    def test_unsorted_input_is_ordered_before_merge(self):
+        """Out-of-order sequences are merged by chronological adjacency."""
+        proc = _bare_processor()
+        seqA = _make_seq("s1", "TargetA", start_min=0, duration_min=20)
+        seqB = _make_seq("s2", "TargetA", start_min=20, duration_min=20)
+        cal = _make_calendar([seqB, seqA])  # reversed order
+
+        result = proc._merge_similar_observations(cal)
+
+        seqs = result.visits[0].sequences
+        assert len(seqs) == 1
+        assert seqs[0].id == "s1"
+        assert seqs[0].start_time == seqA.start_time
+        assert seqs[0].stop_time == seqB.stop_time
+
+    def test_input_calendar_not_mutated(self):
+        """The original calendar/sequences are left untouched."""
+        proc = _bare_processor()
+        seqA = _make_seq("s1", "TargetA", start_min=0, duration_min=20)
+        seqB = _make_seq("s2", "TargetA", start_min=20, duration_min=30)
+        original_stop = seqA.stop_time
+        cal = _make_calendar([seqA, seqB])
+
+        proc._merge_similar_observations(cal)
+
+        # Original visit still has both sequences, unchanged.
+        assert len(cal.visits[0].sequences) == 2
+        assert cal.visits[0].sequences[0].stop_time == original_stop
+
+
+# ================================================================
+# Tests: integration via process_calendar
+# ================================================================
+
+
+class _DummyVisibilityAllTrue:
+    """Visibility mock — always visible, ignores roll."""
+
+    def __init__(self, l1, l2, **kwargs):
+        pass
+
+    def get_visibility(self, coord, times, roll=None):
+        try:
+            n = len(times)
+        except Exception:
+            return np.array([True], dtype=bool)
+        return np.ones(n, dtype=bool)
+
+
+class TestProcessCalendarMergeKwarg:
+    """process_calendar(merge_similar_observations=...) wiring."""
+
+    def _load_sample(self):
+        import shortschedule
+
+        sample = (
+            Path(shortschedule.__file__).parent
+            / "data"
+            / "Pandora_science_calendar_20251018_tsb-futz.xml"
+        )
+        from shortschedule.parser import parse_science_calendar
+
+        cal = parse_science_calendar(sample)
+        if not cal.visits:
+            pytest.skip("Sample calendar has no visits")
+        return cal
+
+    @pytest.mark.slow
+    def test_merge_reduces_sequence_count(self, monkeypatch):
+        """Enabling the merge never increases the sequence count and
+        produces no zero-length result."""
+        monkeypatch.setattr(
+            "shortschedule.scheduler.Visibility",
+            _DummyVisibilityAllTrue,
+        )
+        cal = self._load_sample()
+        first_seq = cal.visits[0].sequences[0]
+
+        sched_off = ScheduleProcessor("L1", "L2")
+        off = sched_off.process_calendar(
+            cal.copy(),
+            window_start=first_seq.start_time.isot,
+            window_duration_days=1,
+            merge_similar_observations=False,
+        )
+
+        sched_on = ScheduleProcessor("L1", "L2")
+        on = sched_on.process_calendar(
+            cal.copy(),
+            window_start=first_seq.start_time.isot,
+            window_duration_days=1,
+            merge_similar_observations=True,
+        )
+
+        n_off = sum(len(v.sequences) for v in off.visits)
+        n_on = sum(len(v.sequences) for v in on.visits)
+        assert n_on <= n_off
+        assert n_on > 0
+
+    @pytest.mark.slow
+    def test_merge_disabled_by_default(self, monkeypatch):
+        """Omitting the kwarg leaves merging off (no error, processes)."""
+        monkeypatch.setattr(
+            "shortschedule.scheduler.Visibility",
+            _DummyVisibilityAllTrue,
+        )
+        cal = self._load_sample()
+        first_seq = cal.visits[0].sequences[0]
+        sched = ScheduleProcessor("L1", "L2")
+        processed = sched.process_calendar(
+            cal,
+            window_start=first_seq.start_time.isot,
+            window_duration_days=1,
+        )
+        assert processed is not None

--- a/tests/test_merge_observations.py
+++ b/tests/test_merge_observations.py
@@ -249,7 +249,7 @@ class TestProcessCalendarMergeKwarg:
         return cal
 
     @pytest.mark.slow
-    def test_merge_reduces_sequence_count(self, monkeypatch):
+    def test_merge_reduces_sequence_count(self, monkeypatch, tmp_path):
         """Enabling the merge never increases the sequence count and
         produces no zero-length result."""
         monkeypatch.setattr(
@@ -265,6 +265,7 @@ class TestProcessCalendarMergeKwarg:
             window_start=first_seq.start_time.isot,
             window_duration_days=1,
             merge_similar_observations=False,
+            log_path=tmp_path / "off",
         )
 
         sched_on = ScheduleProcessor("L1", "L2")
@@ -273,6 +274,7 @@ class TestProcessCalendarMergeKwarg:
             window_start=first_seq.start_time.isot,
             window_duration_days=1,
             merge_similar_observations=True,
+            log_path=tmp_path / "on",
         )
 
         n_off = sum(len(v.sequences) for v in off.visits)
@@ -281,7 +283,7 @@ class TestProcessCalendarMergeKwarg:
         assert n_on > 0
 
     @pytest.mark.slow
-    def test_merge_disabled_by_default(self, monkeypatch):
+    def test_merge_disabled_by_default(self, monkeypatch, tmp_path):
         """Omitting the kwarg leaves merging off (no error, processes)."""
         monkeypatch.setattr(
             "shortschedule.scheduler.Visibility",
@@ -294,5 +296,6 @@ class TestProcessCalendarMergeKwarg:
             cal,
             window_start=first_seq.start_time.isot,
             window_duration_days=1,
+            log_path=tmp_path / "run",
         )
         assert processed is not None

--- a/tests/test_metadata_roundtrip.py
+++ b/tests/test_metadata_roundtrip.py
@@ -1,6 +1,6 @@
 # Standard library
-import os
 import xml.etree.ElementTree as ET
+from pathlib import Path
 
 # Third-party
 import numpy as np
@@ -25,9 +25,10 @@ class DummyVisibilityAllTrue:
 
 
 def get_sample_calendar_path():
-    pkgdir = os.path.dirname(shortschedule.__file__)
-    return os.path.join(
-        pkgdir, "data", "Pandora_science_calendar_20251018_tsb-futz.xml"
+    return (
+        Path(shortschedule.__file__).parent
+        / "data"
+        / "Pandora_science_calendar_20251018_tsb-futz.xml"
     )
 
 
@@ -38,7 +39,7 @@ def test_processed_calendar_metadata_written(monkeypatch, tmp_path):
     )
 
     sample = get_sample_calendar_path()
-    assert os.path.exists(sample), f"Sample calendar not found at {sample}"
+    assert sample.exists(), f"Sample calendar not found at {sample}"
 
     cal = parse_science_calendar(sample)
     assert len(cal.visits) > 0
@@ -54,7 +55,7 @@ def test_processed_calendar_metadata_written(monkeypatch, tmp_path):
     out_file = tmp_path / "processed_meta.xml"
     XMLWriter().write_calendar(processed, str(out_file))
 
-    assert os.path.exists(out_file), "Output file was not created"
+    assert out_file.exists(), "Output file was not created"
 
     root = ET.parse(str(out_file)).getroot()
     # ElementTree places elements in the default namespace if one is set on

--- a/tests/test_metadata_roundtrip.py
+++ b/tests/test_metadata_roundtrip.py
@@ -77,3 +77,38 @@ def test_processed_calendar_metadata_written(monkeypatch, tmp_path):
     assert "tle_line1" in attrs or "tle_line1".lower() in attrs
     assert "tle_line2" in attrs or "tle_line2".lower() in attrs
     assert "created" in attrs or "created".lower() in attrs
+
+    # The short-term scheduler version must be stamped into the calendar.
+    assert "short_term_scheduler_version" in attrs
+    assert attrs["short_term_scheduler_version"] == shortschedule.get_version()
+
+
+def test_version_written_with_default_metadata(tmp_path):
+    """The version is stamped even for a calendar with no source metadata."""
+    from astropy.time import Time, TimeDelta
+
+    from shortschedule.models import (
+        ObservationSequence,
+        ScienceCalendar,
+        Visit,
+    )
+
+    start = Time("2026-03-01T00:00:00", scale="utc")
+    seq = ObservationSequence(
+        id="001",
+        target="T",
+        priority=0,
+        start_time=start,
+        stop_time=start + TimeDelta(3600, format="sec"),
+        ra=1.0,
+        dec=2.0,
+        payload_params={},
+    )
+    cal = ScienceCalendar(metadata={}, visits=[Visit("0001", [seq])])
+    out_file = tmp_path / "v.xml"
+    XMLWriter().write_calendar(cal, str(out_file))
+
+    root = ET.parse(str(out_file)).getroot()
+    meta = next(c for c in root if c.tag.endswith("Meta"))
+    attrs = {k.lower(): v for k, v in meta.attrib.items()}
+    assert attrs["short_term_scheduler_version"] == shortschedule.get_version()

--- a/tests/test_metadata_roundtrip.py
+++ b/tests/test_metadata_roundtrip.py
@@ -49,7 +49,11 @@ def test_processed_calendar_metadata_written(monkeypatch, tmp_path):
 
     sched = ScheduleProcessor("LINE1_EXAMPLE", "LINE2_EXAMPLE")
     processed = sched.process_calendar(
-        cal, window_start=window_start, window_duration_days=1, verbose=False
+        cal,
+        window_start=window_start,
+        window_duration_days=1,
+        log_path=tmp_path / "run",
+        verbose=False,
     )
 
     out_file = tmp_path / "processed_meta.xml"

--- a/tests/test_nirda.py
+++ b/tests/test_nirda.py
@@ -772,3 +772,44 @@ class TestAdditionalOverheadInSolveDuration:
         nd = _make(additional_overhead_time=5e-3 * u.s)
         duration, _, _ = nd.solve_duration(0, 0 * u.s, 0 * u.s)
         assert duration.to(u.s).value == 0.0
+
+
+# ---------------------------------------------------------------------------
+# Payload config spec / get_config
+# ---------------------------------------------------------------------------
+class TestNirdaConfigSpec:
+    """Tests for the payload config mapping and get_config()."""
+
+    def test_get_config_keys_match_spec(self):
+        """get_config returns exactly the CONFIG_SPEC field names."""
+        nd = NirdaData()
+        assert set(nd.get_config().keys()) == set(NirdaData.CONFIG_SPEC.keys())
+
+    def test_get_config_returns_current_values(self):
+        """get_config reflects this instance's field values."""
+        nd = _make(drop_frames_1=7, groups=9)
+        cfg = nd.get_config()
+        assert cfg["drop_frames_1"] == 7
+        assert cfg["groups"] == 9
+
+    def test_spec_fields_are_real_attributes(self):
+        """Every CONFIG_SPEC field is a real NirdaData attribute."""
+        nd = NirdaData()
+        for field_name in NirdaData.CONFIG_SPEC:
+            assert hasattr(nd, field_name)
+
+    def test_payload_section_is_inf_cam(self):
+        """NIRDA config lives under the AcquireInfCamImages payload."""
+        assert NirdaData.PAYLOAD_SECTION == "AcquireInfCamImages"
+
+    def test_required_fields_exclude_average_groups(self):
+        """average_groups is optional (affects data volume only)."""
+        assert "average_groups" not in NirdaData.REQUIRED_CONFIG_FIELDS
+        assert "groups" in NirdaData.REQUIRED_CONFIG_FIELDS
+
+    def test_roundtrip_converters(self):
+        """from_xml(to_xml(value)) round-trips for a sample field."""
+        tag, from_xml, to_xml = NirdaData.CONFIG_SPEC["drop_frames_1"]
+        assert from_xml(to_xml(5)) == 5
+        # Floats in the payload text parse to ints.
+        assert from_xml("5.0") == 5

--- a/tests/test_nirda.py
+++ b/tests/test_nirda.py
@@ -423,15 +423,19 @@ class TestUpdateForVitl:
         nd.update_for_vitl((_RESET_1 + 50) * nd.single_frame_time)
         assert nd.first_integration_time.to(u.s).value != old_first
 
-    def test_zero_frame_time_gives_one_reset(self):
-        """If reset_frame_time is zero update_for_vitl must not divide by zero."""
+    def test_zero_frame_time_gives_floor_reset(self):
+        """If reset_frame_time is zero update_for_vitl must not divide by zero.
+
+        With no usable frame duration the count falls back to the fixed floor
+        of two reset frames rather than dividing by zero.
+        """
         # A zero-area ROI drives single_frame_time (and thus reset_frame_time) to zero.
         nd = _make(
             roi_x_size=0, roi_y_size=0, roi_x_buffer_pixels=0, roi_y_buffer_pixels=0
         )
         assert nd.reset_frame_time.to(u.s).value == 0.0
         nd.update_for_vitl(10.0 * u.s)
-        assert nd.reset_frames_1 == 1
+        assert nd.reset_frames_1 == 2
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_nirda.py
+++ b/tests/test_nirda.py
@@ -417,11 +417,11 @@ class TestUpdateForVitl:
         nd.update_for_vitl(settling)
         assert nd.reset_frames_1 >= 1
 
-    def test_zero_settling_gives_one_frame(self):
-        """Zero settling time should still require one reset frame."""
+    def test_zero_settling_gives_floor_resets(self):
+        """Zero settling time should still apply the minimum reset-frame floor."""
         nd = _make()
         nd.update_for_vitl(0.0 * u.s)
-        assert nd.reset_frames_1 == 1
+        assert nd.reset_frames_1 == 2
 
     def test_derived_attributes_recomputed(self):
         """Derived attributes should be updated after update_for_vitl."""

--- a/tests/test_nirda.py
+++ b/tests/test_nirda.py
@@ -22,6 +22,15 @@ from astropy import units as u
 
 # First-party/Local
 from shortschedule.nirda import NirdaData
+from shortschedule.overhead import OverheadTiming
+
+
+def _nirda_overhead(pre=0 * u.s, post=0 * u.s):
+    """OverheadTiming carrying only the NIRDA pre/post overheads under test."""
+    return OverheadTiming(
+        nirda_pre_overhead_time=pre,
+        nirda_post_overhead_time=post,
+    )
 
 # ---------------------------------------------------------------------------
 # Shared test fixture — small, round-number parameters for easy hand calculation
@@ -459,7 +468,7 @@ class TestSolveIntegrations:
     def test_zero_duration_yields_zero_integrations(self):
         """A zero-length window should produce no integrations."""
         nd = _make()
-        integrations, data, data_c = nd.solve_integrations(0.0 * u.s, 0 * u.s, 0 * u.s)
+        integrations, data, data_c = nd.solve_integrations(0.0 * u.s, _nirda_overhead())
         assert integrations == 0
         assert data.to(u.byte).value == 0
         assert data_c.to(u.byte).value == 0
@@ -470,7 +479,7 @@ class TestSolveIntegrations:
         # Use the object's own first_integration_time so the boundary is exact
         # regardless of floating-point ordering in the derived constants.
         integrations, _, _ = nd.solve_integrations(
-            nd.first_integration_time, 0 * u.s, 0 * u.s
+            nd.first_integration_time, _nirda_overhead()
         )
         assert integrations == 1
 
@@ -484,7 +493,7 @@ class TestSolveIntegrations:
             + nd.other_integration_time * 3
             + nd.other_integration_time * 1e-6
         )
-        integrations, _, _ = nd.solve_integrations(duration, 0 * u.s, 0 * u.s)
+        integrations, _, _ = nd.solve_integrations(duration, _nirda_overhead())
         assert integrations == 4
 
     def test_overhead_reduces_count(self):
@@ -493,9 +502,9 @@ class TestSolveIntegrations:
         # Window fits several integrations; a pre-overhead of two integrations'
         # worth must remove at least one.
         duration = (_FIRST_INT_TIME + 3 * _OTHER_INT_TIME) * u.s
-        n_no_oh, _, _ = nd.solve_integrations(duration, 0 * u.s, 0 * u.s)
+        n_no_oh, _, _ = nd.solve_integrations(duration, _nirda_overhead())
         n_with_oh, _, _ = nd.solve_integrations(
-            duration, _OTHER_INT_TIME * 2 * u.s, 0 * u.s
+            duration, _nirda_overhead(_OTHER_INT_TIME * 2 * u.s)
         )
         assert n_with_oh < n_no_oh
 
@@ -503,14 +512,14 @@ class TestSolveIntegrations:
         """data should equal integrations * integration_data."""
         nd = _make()
         duration = 56e-3 * u.s
-        integrations, data, _ = nd.solve_integrations(duration, 0 * u.s, 0 * u.s)
+        integrations, data, _ = nd.solve_integrations(duration, _nirda_overhead())
         expected = integrations * nd.integration_data
         assert abs(data.to(u.byte).value - expected.to(u.byte).value) < 1e-10
 
     def test_compressed_data_uses_compression_ratio(self):
         """data_compressed should equal data * compression_ratio."""
         nd = _make(compression_ratio=0.5)
-        _, data, data_c = nd.solve_integrations(56e-3 * u.s, 0 * u.s, 0 * u.s)
+        _, data, data_c = nd.solve_integrations(56e-3 * u.s, _nirda_overhead())
         assert abs(data_c.to(u.byte).value - 0.5 * data.to(u.byte).value) < 1e-10
 
     def test_dropped_integrations_reduce_count(self):
@@ -520,8 +529,8 @@ class TestSolveIntegrations:
         # Window comfortably fits more than two integrations so the raw count
         # stays above the dropped count.
         duration = (_FIRST_INT_TIME + 3 * _OTHER_INT_TIME) * u.s
-        n_no, _, _ = nd_no_drop.solve_integrations(duration, 0 * u.s, 0 * u.s)
-        n_drop, _, _ = nd_dropped.solve_integrations(duration, 0 * u.s, 0 * u.s)
+        n_no, _, _ = nd_no_drop.solve_integrations(duration, _nirda_overhead())
+        n_drop, _, _ = nd_dropped.solve_integrations(duration, _nirda_overhead())
         assert n_no - n_drop == 2
 
     def test_dropped_integrations_cannot_go_below_zero(self):
@@ -537,8 +546,8 @@ class TestSolveIntegrations:
         # Window fits two integrations; one integration's worth of additional
         # overhead must drop the count.
         duration = (_FIRST_INT_TIME + _OTHER_INT_TIME) * u.s + _OTHER_INT_TIME * 1e-6 * u.s
-        n_no, _, _ = nd_no_oh.solve_integrations(duration, 0 * u.s, 0 * u.s)
-        n_with, _, _ = nd_with_oh.solve_integrations(duration, 0 * u.s, 0 * u.s)
+        n_no, _, _ = nd_no_oh.solve_integrations(duration, _nirda_overhead())
+        n_with, _, _ = nd_with_oh.solve_integrations(duration, _nirda_overhead())
         assert n_with < n_no
 
     def test_duration_shorter_than_first_integration_gives_zero(self):
@@ -547,7 +556,7 @@ class TestSolveIntegrations:
         # Just under the object's own first_integration_time, scaled so it works
         # at any magnitude.
         duration = nd.first_integration_time * (1 - 1e-6)
-        integrations, _, _ = nd.solve_integrations(duration, 0 * u.s, 0 * u.s)
+        integrations, _, _ = nd.solve_integrations(duration, _nirda_overhead())
         assert integrations == 0
 
 
@@ -580,7 +589,7 @@ class TestSolveDuration:
     def test_one_integration_duration(self):
         """One integration: duration = first_integration_time + overheads."""
         nd = _make()
-        duration, _, _ = nd.solve_duration(1, 0 * u.s, 0 * u.s)
+        duration, _, _ = nd.solve_duration(1, _nirda_overhead())
         expected = _FIRST_INT_TIME
         assert abs(duration.to(u.s).value - expected) < 1e-12
 
@@ -589,15 +598,15 @@ class TestSolveDuration:
         nd = _make()
         n = 4
         expected = _FIRST_INT_TIME + 3 * _OTHER_INT_TIME
-        duration, _, _ = nd.solve_duration(n, 0 * u.s, 0 * u.s)
+        duration, _, _ = nd.solve_duration(n, _nirda_overhead())
         assert abs(duration.to(u.s).value - expected) < 1e-12
 
     def test_overhead_added_to_duration(self):
         """Overhead parameters should be added to the total duration."""
         nd = _make()
         pre, post = 30e-3 * u.s, 10e-3 * u.s
-        dur_no_oh, _, _ = nd.solve_duration(3, 0 * u.s, 0 * u.s)
-        dur_with_oh, _, _ = nd.solve_duration(3, pre, post)
+        dur_no_oh, _, _ = nd.solve_duration(3, _nirda_overhead())
+        dur_with_oh, _, _ = nd.solve_duration(3, _nirda_overhead(pre, post))
         assert abs(
             dur_with_oh.to(u.s).value - dur_no_oh.to(u.s).value - 40e-3
         ) < 1e-12
@@ -606,29 +615,29 @@ class TestSolveDuration:
         """data should be integrations * integration_data."""
         nd = _make()
         n = 5
-        _, data, _ = nd.solve_duration(n, 0 * u.s, 0 * u.s)
+        _, data, _ = nd.solve_duration(n, _nirda_overhead())
         expected = n * nd.integration_data.to(u.byte).value
         assert abs(data.to(u.byte).value - expected) < 1e-10
 
     def test_compressed_data_uses_compression_ratio(self):
         """data_compressed should equal data * compression_ratio."""
         nd = _make(compression_ratio=0.6)
-        _, data, data_c = nd.solve_duration(4, 0 * u.s, 0 * u.s)
+        _, data, data_c = nd.solve_duration(4, _nirda_overhead())
         assert abs(data_c.to(u.byte).value - 0.6 * data.to(u.byte).value) < 1e-10
 
     def test_dropped_integrations_ignored(self):
         """dropped_integrations must not affect solve_duration (by spec)."""
         nd_no_drop = _make(dropped_integrations=0)
         nd_dropped = _make(dropped_integrations=5)
-        dur_no, _, _ = nd_no_drop.solve_duration(4, 0 * u.s, 0 * u.s)
-        dur_drop, _, _ = nd_dropped.solve_duration(4, 0 * u.s, 0 * u.s)
+        dur_no, _, _ = nd_no_drop.solve_duration(4, _nirda_overhead())
+        dur_drop, _, _ = nd_dropped.solve_duration(4, _nirda_overhead())
         assert dur_no == dur_drop
 
     def test_duration_increases_monotonically(self):
         """More integrations should always require more time."""
         nd = _make()
         durations = [
-            nd.solve_duration(n, 0 * u.s, 0 * u.s)[0].to(u.s).value
+            nd.solve_duration(n, _nirda_overhead())[0].to(u.s).value
             for n in range(1, 6)
         ]
         for i in range(len(durations) - 1):
@@ -645,10 +654,10 @@ class TestSolveRoundtrip:
         """With no overhead, solve_duration then solve_integrations should return n."""
         nd = _make()
         for n in range(1, 8):
-            duration, _, _ = nd.solve_duration(n, 0 * u.s, 0 * u.s)
+            duration, _, _ = nd.solve_duration(n, _nirda_overhead())
             # Tiny relative guard against floating-point loss when re-dividing.
             duration = duration + nd.other_integration_time * 1e-6
-            recovered, _, _ = nd.solve_integrations(duration, 0 * u.s, 0 * u.s)
+            recovered, _, _ = nd.solve_integrations(duration, _nirda_overhead())
             assert recovered == n, f"Roundtrip failed for n={n}: recovered {recovered}"
 
     def test_roundtrip_with_overhead(self):
@@ -656,11 +665,11 @@ class TestSolveRoundtrip:
         nd = _make()
         pre, post = 20e-3 * u.s, 10e-3 * u.s
         for n in range(1, 6):
-            duration, _, _ = nd.solve_duration(n, pre, post)
+            duration, _, _ = nd.solve_duration(n, _nirda_overhead(pre, post))
             # Add a tiny relative epsilon so floating-point boundary comparisons
             # stay on the correct (>=) side without fitting an extra integration.
             duration = duration + nd.other_integration_time * 1e-6
-            recovered, _, _ = nd.solve_integrations(duration, pre, post)
+            recovered, _, _ = nd.solve_integrations(duration, _nirda_overhead(pre, post))
             assert recovered == n, (
                 f"Roundtrip with overhead failed for n={n}: recovered {recovered}"
             )
@@ -673,8 +682,8 @@ class TestSolveRoundtrip:
         # So ask for n_science raw (no drops) → duration → back out drops correctly
         n_science = 4
         n_total = n_science + dropped  # what solve_duration will schedule
-        duration, _, _ = nd.solve_duration(n_total, 0 * u.s, 0 * u.s)
-        recovered, _, _ = nd.solve_integrations(duration, 0 * u.s, 0 * u.s)
+        duration, _, _ = nd.solve_duration(n_total, _nirda_overhead())
+        recovered, _, _ = nd.solve_integrations(duration, _nirda_overhead())
         assert recovered == n_science
 
 
@@ -761,8 +770,8 @@ class TestAdditionalOverheadInSolveDuration:
         """solve_duration should add additional_overhead_time to the total."""
         nd_no_oh = _make(additional_overhead_time=0 * u.s)
         nd_with_oh = _make(additional_overhead_time=5e-3 * u.s)
-        dur_no, _, _ = nd_no_oh.solve_duration(3, 0 * u.s, 0 * u.s)
-        dur_with, _, _ = nd_with_oh.solve_duration(3, 0 * u.s, 0 * u.s)
+        dur_no, _, _ = nd_no_oh.solve_duration(3, _nirda_overhead())
+        dur_with, _, _ = nd_with_oh.solve_duration(3, _nirda_overhead())
         assert abs(
             dur_with.to(u.s).value - dur_no.to(u.s).value - 5e-3
         ) < 1e-12
@@ -770,7 +779,7 @@ class TestAdditionalOverheadInSolveDuration:
     def test_additional_overhead_not_added_when_zero_integrations(self):
         """Zero integrations should give zero duration regardless of overhead."""
         nd = _make(additional_overhead_time=5e-3 * u.s)
-        duration, _, _ = nd.solve_duration(0, 0 * u.s, 0 * u.s)
+        duration, _, _ = nd.solve_duration(0, _nirda_overhead())
         assert duration.to(u.s).value == 0.0
 
 

--- a/tests/test_nirda.py
+++ b/tests/test_nirda.py
@@ -1,0 +1,567 @@
+"""Unit tests for the NirdaData class in shortschedule.nirda.
+
+Tests cover:
+- Default construction and derived-attribute values
+- pixels_per_frame and single_frame_time calculations
+- Reset-frame-time sentinel resolution
+- First vs subsequent integration time formulas
+- Integration data and saved-frame counts (average_groups on/off)
+- update_for_vitl reset-frame adjustment
+- solve_integrations duration decomposition
+- solve_duration integration-count inversion
+- Roundtrip consistency between solve_integrations and solve_duration
+- Edge cases: zero ROI, zero duration, dropped integrations
+"""
+
+# Third-party
+import math
+
+import pytest
+from astropy import units as u
+
+# First-party/Local
+from shortschedule.nirda import NirdaData
+
+# ---------------------------------------------------------------------------
+# Shared test fixture — small, round-number parameters for easy hand calculation
+#
+# roi_x_size=10, roi_y_size=10, roi_x_buffer_pixels=0, roi_y_buffer_pixels=0
+# pixels_per_frame = 10 * 10 = 100
+# single_frame_time = 100 * 1e-5 s = 1e-3 s
+#
+# reset_frames_1=5, reset_frames_2=1
+# drop_frames_1=0, drop_frames_2=0, drop_frames_3=0
+# read_frames=4, groups=3
+#
+# common_frames = 0 + (3-1)*0 + 0 + 3*4 = 12
+# first_integration_time  = (12 + 5) * 1e-3 = 17e-3 s
+# other_integration_time  = (12 + 1) * 1e-3 = 13e-3 s
+# ---------------------------------------------------------------------------
+
+_SIMPLE = dict(
+    reset_frames_1=5,
+    reset_frames_2=1,
+    drop_frames_1=0,
+    drop_frames_2=0,
+    drop_frames_3=0,
+    read_frames=4,
+    groups=3,
+    average_groups=True,
+    roi_x_size=10,
+    roi_y_size=10,
+    roi_x_buffer_pixels=0,
+    roi_y_buffer_pixels=0,
+    bytes_per_pixel=2 * u.byte,
+    dropped_integrations=0,
+    compression_ratio=0.8,
+    reset_frame_time=-1.0 * u.s,  # sentinel → becomes single_frame_time
+    additional_overhead_time=0 * u.s,
+)
+
+_FRAME_TIME = 1e-3  # seconds, derived from _SIMPLE
+_FIRST_INT_TIME = 17e-3  # seconds
+_OTHER_INT_TIME = 13e-3  # seconds
+_PIXELS = 100
+_BYTES_PER_FRAME = 200  # bytes  (2 bytes/pixel * 100 pixels)
+
+
+def _make(**overrides):
+    """Return a NirdaData built from _SIMPLE with optional field overrides."""
+    kwargs = {**_SIMPLE, **overrides}
+    return NirdaData(**kwargs)
+
+
+# ---------------------------------------------------------------------------
+# Default construction
+# ---------------------------------------------------------------------------
+class TestNirdaDataDefaults:
+    """NirdaData() with library defaults should produce sensible derived values."""
+
+    def test_default_construction_succeeds(self):
+        """NirdaData with all defaults should not raise."""
+        nd = NirdaData()
+        assert nd is not None
+
+    def test_default_pixels_per_frame(self):
+        """Default pixels_per_frame should match (roi_x+buf) * (roi_y+buf)."""
+        nd = NirdaData()
+        expected = (nd.roi_x_size + nd.roi_x_buffer_pixels) * (
+            nd.roi_y_size + nd.roi_y_buffer_pixels
+        )
+        assert nd.pixels_per_frame == expected
+
+    def test_default_single_frame_time_is_positive(self):
+        """Default single_frame_time should be a positive Quantity in seconds."""
+        nd = NirdaData()
+        assert nd.single_frame_time.to(u.s).value > 0
+
+    def test_default_reset_frame_time_sentinel_resolved(self):
+        """Default reset_frame_time sentinel (-1 s) should be replaced with single_frame_time."""
+        nd = NirdaData()
+        assert nd.reset_frame_time == nd.single_frame_time
+
+    def test_default_first_integration_time_exceeds_other(self):
+        """First integration uses more reset frames so it should take longer."""
+        nd = NirdaData()
+        assert nd.first_integration_time > nd.other_integration_time
+
+    def test_default_dropped_integration_time_equals_other(self):
+        """dropped_integration_time should mirror other_integration_time."""
+        nd = NirdaData()
+        assert nd.dropped_integration_time == nd.other_integration_time
+
+    def test_default_integration_data_positive(self):
+        """Default integration_data should be positive."""
+        nd = NirdaData()
+        assert nd.integration_data.to(u.byte).value > 0
+
+
+# ---------------------------------------------------------------------------
+# pixels_per_frame
+# ---------------------------------------------------------------------------
+class TestPixelsPerFrame:
+    """Tests for the pixels_per_frame derived attribute."""
+
+    def test_no_buffer(self):
+        """With zero buffer pixels the result is just roi_x * roi_y."""
+        nd = _make()
+        assert nd.pixels_per_frame == _PIXELS
+
+    def test_with_x_buffer(self):
+        """x-buffer pixels are added to the column count."""
+        nd = _make(roi_x_buffer_pixels=5)
+        assert nd.pixels_per_frame == (10 + 5) * 10
+
+    def test_with_y_buffer(self):
+        """y-buffer pixels are added to the row count."""
+        nd = _make(roi_y_buffer_pixels=3)
+        assert nd.pixels_per_frame == 10 * (10 + 3)
+
+    def test_with_both_buffers(self):
+        """Both buffers contribute independently."""
+        nd = _make(roi_x_buffer_pixels=2, roi_y_buffer_pixels=2)
+        assert nd.pixels_per_frame == 12 * 12
+
+    def test_zero_roi_gives_zero(self):
+        """A zero-area ROI should yield zero pixels per frame."""
+        nd = _make(roi_x_size=0, roi_y_size=0)
+        assert nd.pixels_per_frame == 0
+
+
+# ---------------------------------------------------------------------------
+# single_frame_time
+# ---------------------------------------------------------------------------
+class TestSingleFrameTime:
+    """Tests for the single_frame_time derived attribute."""
+
+    def test_value(self):
+        """single_frame_time should equal pixels_per_frame * read_time_per_pixel."""
+        nd = _make()
+        expected = _PIXELS * 1.0e-5
+        assert abs(nd.single_frame_time.to(u.s).value - expected) < 1e-15
+
+    def test_units_are_seconds(self):
+        """single_frame_time should be in seconds."""
+        nd = _make()
+        _ = nd.single_frame_time.to(u.s)  # should not raise
+
+    def test_zero_pixels_zero_frame_time(self):
+        """Zero-size ROI should give zero frame time."""
+        nd = _make(roi_x_size=0, roi_y_size=0)
+        assert nd.single_frame_time.to(u.s).value == 0
+
+    def test_faster_clock_gives_shorter_frame(self):
+        """Halving read_time_per_pixel should halve single_frame_time."""
+        nd_slow = _make(read_time_per_pixel=2e-5 * u.s)
+        nd_fast = _make(read_time_per_pixel=1e-5 * u.s)
+        assert abs(
+            nd_slow.single_frame_time.to(u.s).value
+            / nd_fast.single_frame_time.to(u.s).value
+            - 2.0
+        ) < 1e-10
+
+
+# ---------------------------------------------------------------------------
+# Reset-frame-time sentinel
+# ---------------------------------------------------------------------------
+class TestResetFrameTimeSentinel:
+    """Negative reset_frame_time should be replaced; positive should be kept."""
+
+    def test_sentinel_becomes_single_frame_time(self):
+        """Sentinel value (-1 s) should resolve to single_frame_time."""
+        nd = _make(reset_frame_time=-1.0 * u.s)
+        assert nd.reset_frame_time == nd.single_frame_time
+
+    def test_explicit_positive_value_kept(self):
+        """A positive reset_frame_time should be used as-is."""
+        custom = 0.05 * u.s
+        nd = _make(reset_frame_time=custom)
+        assert nd.reset_frame_time == custom
+
+    def test_explicit_zero_value_kept(self):
+        """An explicit zero reset_frame_time should remain zero."""
+        nd = _make(reset_frame_time=0.0 * u.s)
+        assert nd.reset_frame_time.to(u.s).value == 0.0
+
+    def test_sentinel_affects_integration_time(self):
+        """Changing reset_frame_time should change first_integration_time."""
+        nd_default = _make()
+        nd_custom = _make(reset_frame_time=0.1 * u.s)
+        assert nd_custom.first_integration_time != nd_default.first_integration_time
+
+
+# ---------------------------------------------------------------------------
+# Integration time formulas
+# ---------------------------------------------------------------------------
+
+
+class TestIntegrationTimes:
+    """Tests for first_integration_time and other_integration_time."""
+
+    def test_first_integration_time_value(self):
+        """first_integration_time should be (common_frames + reset_frames_1) * frame_time."""
+        nd = _make()
+        assert abs(nd.first_integration_time.to(u.s).value - _FIRST_INT_TIME) < 1e-12
+
+    def test_other_integration_time_value(self):
+        """other_integration_time should be (common_frames + reset_frames_2) * frame_time."""
+        nd = _make()
+        assert abs(nd.other_integration_time.to(u.s).value - _OTHER_INT_TIME) < 1e-12
+
+    def test_first_longer_than_other(self):
+        """First integration is longer because reset_frames_1 > reset_frames_2."""
+        nd = _make()
+        assert nd.first_integration_time > nd.other_integration_time
+
+    def test_equal_resets_give_equal_times(self):
+        """When reset_frames_1 == reset_frames_2 both times are equal."""
+        nd = _make(reset_frames_1=3, reset_frames_2=3)
+        assert nd.first_integration_time == nd.other_integration_time
+
+    def test_more_groups_increases_integration_time(self):
+        """Adding groups increases common_frames and therefore integration time."""
+        nd_few = _make(groups=2)
+        nd_many = _make(groups=6)
+        assert nd_many.other_integration_time > nd_few.other_integration_time
+
+    def test_more_drop_frames_2_increases_integration_time(self):
+        """Non-zero drop_frames_2 between groups lengthens integration time."""
+        nd_no_drop = _make(drop_frames_2=0)
+        nd_with_drop = _make(drop_frames_2=4)
+        assert nd_with_drop.other_integration_time > nd_no_drop.other_integration_time
+
+    def test_times_nonnegative_with_zero_frames(self):
+        """All-zero frame counts should give zero integration time, not negative."""
+        nd = _make(reset_frames_1=0, reset_frames_2=0, read_frames=0, groups=0)
+        assert nd.first_integration_time.to(u.s).value >= 0
+        assert nd.other_integration_time.to(u.s).value >= 0
+
+
+# ---------------------------------------------------------------------------
+# Integration data and saved-frame counts
+# ---------------------------------------------------------------------------
+class TestIntegrationData:
+    """Tests for integration_data and *_saved_frames attributes."""
+
+    def test_average_groups_true_data(self):
+        """With average_groups=True data is bytes_per_frame * groups."""
+        nd = _make(average_groups=True)
+        expected = _BYTES_PER_FRAME * nd.groups
+        assert abs(nd.integration_data.to(u.byte).value - expected) < 1e-10
+
+    def test_average_groups_false_data(self):
+        """With average_groups=False data is bytes_per_frame * groups * read_frames."""
+        nd = _make(average_groups=False)
+        expected = _BYTES_PER_FRAME * nd.groups * nd.read_frames
+        assert abs(nd.integration_data.to(u.byte).value - expected) < 1e-10
+
+    def test_average_groups_true_saved_frames(self):
+        """With average_groups=True saved_frames equals groups for both integrations."""
+        nd = _make(average_groups=True)
+        assert nd.first_integration_saved_frames == nd.groups
+        assert nd.other_integration_saved_frames == nd.groups
+
+    def test_average_groups_false_saved_frames(self):
+        """With average_groups=False saved_frames equals groups * read_frames."""
+        nd = _make(average_groups=False)
+        expected = nd.groups * nd.read_frames
+        assert nd.first_integration_saved_frames == expected
+        assert nd.other_integration_saved_frames == expected
+
+    def test_averaging_reduces_data(self):
+        """average_groups=True should produce less or equal data than False (when read_frames>1)."""
+        nd_avg = _make(average_groups=True, read_frames=4)
+        nd_raw = _make(average_groups=False, read_frames=4)
+        assert nd_avg.integration_data <= nd_raw.integration_data
+
+    def test_integration_data_units_are_bytes(self):
+        """integration_data should be convertible to bytes."""
+        nd = _make()
+        _ = nd.integration_data.to(u.byte)
+
+
+# ---------------------------------------------------------------------------
+# update_for_vitl
+# ---------------------------------------------------------------------------
+class TestUpdateForVitl:
+    """Tests for the update_for_vitl method."""
+
+    def test_reset_frames_1_set_to_ceiling(self):
+        """reset_frames_1 should be ceil(settling_time / frame_time)."""
+        nd = _make()
+        settling = 7.5e-3 * u.s  # frame_time=1e-3 → ceil(7.5)=8
+        nd.update_for_vitl(settling)
+        assert nd.reset_frames_1 == 8
+
+    def test_exact_multiple_no_extra_frame(self):
+        """Exact multiple of frame_time should need no extra frame."""
+        nd = _make()
+        settling = 5e-3 * u.s  # exactly 5 frame times
+        nd.update_for_vitl(settling)
+        assert nd.reset_frames_1 == 5
+
+    def test_minimum_one_reset_frame(self):
+        """Even a very short settling time should give at least one reset frame."""
+        nd = _make()
+        settling = 1e-15 * u.s
+        nd.update_for_vitl(settling)
+        assert nd.reset_frames_1 >= 1
+
+    def test_zero_settling_gives_one_frame(self):
+        """Zero settling time should still require one reset frame."""
+        nd = _make()
+        nd.update_for_vitl(0.0 * u.s)
+        assert nd.reset_frames_1 == 1
+
+    def test_derived_attributes_recomputed(self):
+        """Derived attributes should be updated after update_for_vitl."""
+        nd = _make()
+        old_first = nd.first_integration_time.to(u.s).value
+        nd.update_for_vitl(100e-3 * u.s)  # much longer settling → more resets
+        assert nd.first_integration_time.to(u.s).value != old_first
+
+    def test_zero_frame_time_gives_one_reset(self):
+        """If reset_frame_time is zero update_for_vitl must not divide by zero."""
+        nd = _make(reset_frame_time=0.0 * u.s, roi_x_size=0, roi_y_size=0)
+        nd.update_for_vitl(10.0 * u.s)
+        assert nd.reset_frames_1 == 1
+
+
+# ---------------------------------------------------------------------------
+# solve_integrations
+# ---------------------------------------------------------------------------
+class TestSolveIntegrations:
+    """Tests for solve_integrations(duration, pre_overhead, post_overhead)."""
+
+    def test_returns_three_tuple(self):
+        """solve_integrations should return (integrations, data, data_compressed)."""
+        nd = _make()
+        result = nd.solve_integrations(100e-3 * u.s)
+        assert len(result) == 3
+
+    def test_integrations_is_int(self):
+        """Integration count should be an integer."""
+        nd = _make()
+        integrations, _, _ = nd.solve_integrations(100e-3 * u.s)
+        assert isinstance(integrations, int)
+
+    def test_zero_duration_yields_zero_integrations(self):
+        """A zero-length window should produce no integrations."""
+        nd = _make()
+        integrations, data, data_c = nd.solve_integrations(0.0 * u.s, 0 * u.s, 0 * u.s)
+        assert integrations == 0
+        assert data.to(u.byte).value == 0
+        assert data_c.to(u.byte).value == 0
+
+    def test_exact_first_integration_window(self):
+        """Duration exactly equal to first_integration_time should give one integration."""
+        nd = _make()
+        integrations, _, _ = nd.solve_integrations(_FIRST_INT_TIME * u.s, 0 * u.s, 0 * u.s)
+        assert integrations == 1
+
+    def test_multiple_integrations_count(self):
+        """Duration covering multiple integrations should be counted correctly."""
+        nd = _make()
+        # Use object's derived times + 1 ns guard to stay above the exact boundary
+        # without crossing into the next integration window (other_int ≈ 13 ms).
+        duration = nd.first_integration_time + nd.other_integration_time * 3 + 1e-9 * u.s
+        integrations, _, _ = nd.solve_integrations(duration, 0 * u.s, 0 * u.s)
+        assert integrations == 4
+
+    def test_overhead_reduces_count(self):
+        """Adding overhead should reduce the number of integrations."""
+        nd = _make()
+        duration = 100e-3 * u.s
+        n_no_oh, _, _ = nd.solve_integrations(duration, 0 * u.s, 0 * u.s)
+        n_with_oh, _, _ = nd.solve_integrations(duration, 30e-3 * u.s, 0 * u.s)
+        assert n_with_oh < n_no_oh
+
+    def test_data_scales_with_integrations(self):
+        """data should equal integrations * integration_data."""
+        nd = _make()
+        duration = 56e-3 * u.s
+        integrations, data, _ = nd.solve_integrations(duration, 0 * u.s, 0 * u.s)
+        expected = integrations * nd.integration_data
+        assert abs(data.to(u.byte).value - expected.to(u.byte).value) < 1e-10
+
+    def test_compressed_data_uses_compression_ratio(self):
+        """data_compressed should equal data * compression_ratio."""
+        nd = _make(compression_ratio=0.5)
+        _, data, data_c = nd.solve_integrations(56e-3 * u.s, 0 * u.s, 0 * u.s)
+        assert abs(data_c.to(u.byte).value - 0.5 * data.to(u.byte).value) < 1e-10
+
+    def test_dropped_integrations_reduce_count(self):
+        """dropped_integrations should be subtracted from the raw count."""
+        nd_no_drop = _make(dropped_integrations=0)
+        nd_dropped = _make(dropped_integrations=2)
+        duration = 100e-3 * u.s
+        n_no, _, _ = nd_no_drop.solve_integrations(duration, 0 * u.s, 0 * u.s)
+        n_drop, _, _ = nd_dropped.solve_integrations(duration, 0 * u.s, 0 * u.s)
+        assert n_no - n_drop == 2
+
+    def test_dropped_integrations_cannot_go_below_zero(self):
+        """Dropping more integrations than available should floor to zero, not negative."""
+        nd = _make(dropped_integrations=1000)
+        integrations, _, _ = nd.solve_integrations(10e-3 * u.s)
+        assert integrations >= 0
+
+    def test_additional_overhead_reduces_count(self):
+        """additional_overhead_time should reduce the effective window."""
+        nd_no_oh = _make(additional_overhead_time=0 * u.s)
+        nd_with_oh = _make(additional_overhead_time=20e-3 * u.s)
+        duration = 60e-3 * u.s
+        n_no, _, _ = nd_no_oh.solve_integrations(duration, 0 * u.s, 0 * u.s)
+        n_with, _, _ = nd_with_oh.solve_integrations(duration, 0 * u.s, 0 * u.s)
+        assert n_with < n_no
+
+    def test_duration_shorter_than_first_integration_gives_zero(self):
+        """If first_integration_time > duration, result should be zero."""
+        nd = _make()
+        duration = (_FIRST_INT_TIME - 1e-6) * u.s
+        integrations, _, _ = nd.solve_integrations(duration, 0 * u.s, 0 * u.s)
+        assert integrations == 0
+
+
+# ---------------------------------------------------------------------------
+# solve_duration
+# ---------------------------------------------------------------------------
+class TestSolveDuration:
+    """Tests for solve_duration(integrations, pre_overhead, post_overhead)."""
+
+    def test_returns_three_tuple(self):
+        """solve_duration should return (duration, data, data_compressed)."""
+        nd = _make()
+        result = nd.solve_duration(5)
+        assert len(result) == 3
+
+    def test_zero_integrations_returns_zero_duration(self):
+        """Requesting zero integrations should give zero duration."""
+        nd = _make()
+        duration, data, data_c = nd.solve_duration(0)
+        assert duration.to(u.s).value == 0.0
+        assert data.to(u.byte).value == 0.0
+
+    def test_negative_integrations_treated_as_zero(self):
+        """Negative integration counts should be treated as zero."""
+        nd = _make()
+        duration, data, _ = nd.solve_duration(-5)
+        assert duration.to(u.s).value == 0.0
+        assert data.to(u.byte).value == 0.0
+
+    def test_one_integration_duration(self):
+        """One integration: duration = first_integration_time + overheads."""
+        nd = _make()
+        duration, _, _ = nd.solve_duration(1, 0 * u.s, 0 * u.s)
+        expected = _FIRST_INT_TIME
+        assert abs(duration.to(u.s).value - expected) < 1e-12
+
+    def test_multiple_integrations_duration(self):
+        """N>1: duration = first + (N-1)*other + overheads."""
+        nd = _make()
+        n = 4
+        expected = _FIRST_INT_TIME + 3 * _OTHER_INT_TIME
+        duration, _, _ = nd.solve_duration(n, 0 * u.s, 0 * u.s)
+        assert abs(duration.to(u.s).value - expected) < 1e-12
+
+    def test_overhead_added_to_duration(self):
+        """Overhead parameters should be added to the total duration."""
+        nd = _make()
+        pre, post = 30e-3 * u.s, 10e-3 * u.s
+        dur_no_oh, _, _ = nd.solve_duration(3, 0 * u.s, 0 * u.s)
+        dur_with_oh, _, _ = nd.solve_duration(3, pre, post)
+        assert abs(
+            dur_with_oh.to(u.s).value - dur_no_oh.to(u.s).value - 40e-3
+        ) < 1e-12
+
+    def test_data_scales_with_integrations(self):
+        """data should be integrations * integration_data."""
+        nd = _make()
+        n = 5
+        _, data, _ = nd.solve_duration(n, 0 * u.s, 0 * u.s)
+        expected = n * nd.integration_data.to(u.byte).value
+        assert abs(data.to(u.byte).value - expected) < 1e-10
+
+    def test_compressed_data_uses_compression_ratio(self):
+        """data_compressed should equal data * compression_ratio."""
+        nd = _make(compression_ratio=0.6)
+        _, data, data_c = nd.solve_duration(4, 0 * u.s, 0 * u.s)
+        assert abs(data_c.to(u.byte).value - 0.6 * data.to(u.byte).value) < 1e-10
+
+    def test_dropped_integrations_ignored(self):
+        """dropped_integrations must not affect solve_duration (by spec)."""
+        nd_no_drop = _make(dropped_integrations=0)
+        nd_dropped = _make(dropped_integrations=5)
+        dur_no, _, _ = nd_no_drop.solve_duration(4, 0 * u.s, 0 * u.s)
+        dur_drop, _, _ = nd_dropped.solve_duration(4, 0 * u.s, 0 * u.s)
+        assert dur_no == dur_drop
+
+    def test_duration_increases_monotonically(self):
+        """More integrations should always require more time."""
+        nd = _make()
+        durations = [
+            nd.solve_duration(n, 0 * u.s, 0 * u.s)[0].to(u.s).value
+            for n in range(1, 6)
+        ]
+        for i in range(len(durations) - 1):
+            assert durations[i + 1] > durations[i]
+
+
+# ---------------------------------------------------------------------------
+# Roundtrip: solve_duration ↔ solve_integrations
+# ---------------------------------------------------------------------------
+class TestSolveRoundtrip:
+    """solve_integrations(solve_duration(n)) should recover n."""
+
+    def test_roundtrip_no_overhead(self):
+        """With no overhead, solve_duration then solve_integrations should return n."""
+        nd = _make()
+        for n in range(1, 8):
+            duration, _, _ = nd.solve_duration(n, 0 * u.s, 0 * u.s)
+            recovered, _, _ = nd.solve_integrations(duration, 0 * u.s, 0 * u.s)
+            assert recovered == n, f"Roundtrip failed for n={n}: recovered {recovered}"
+
+    def test_roundtrip_with_overhead(self):
+        """Roundtrip should also hold when consistent overhead is used in both calls."""
+        nd = _make()
+        pre, post = 20e-3 * u.s, 10e-3 * u.s
+        for n in range(1, 6):
+            duration, _, _ = nd.solve_duration(n, pre, post)
+            # Add a sub-nanosecond epsilon so floating-point boundary comparisons
+            # stay on the correct (>=) side without fitting an extra integration.
+            duration = duration + 1e-9 * u.s
+            recovered, _, _ = nd.solve_integrations(duration, pre, post)
+            assert recovered == n, (
+                f"Roundtrip with overhead failed for n={n}: recovered {recovered}"
+            )
+
+    def test_roundtrip_with_dropped_integrations(self):
+        """With dropped_integrations the schedule must use n_drop+n_science integrations."""
+        dropped = 2
+        nd = _make(dropped_integrations=dropped)
+        # solve_duration ignores drops; solve_integrations subtracts them
+        # So ask for n_science raw (no drops) → duration → back out drops correctly
+        n_science = 4
+        n_total = n_science + dropped  # what solve_duration will schedule
+        duration, _, _ = nd.solve_duration(n_total, 0 * u.s, 0 * u.s)
+        recovered, _, _ = nd.solve_integrations(duration, 0 * u.s, 0 * u.s)
+        assert recovered == n_science

--- a/tests/test_nirda.py
+++ b/tests/test_nirda.py
@@ -3,7 +3,8 @@
 Tests cover:
 - Default construction and derived-attribute values
 - pixels_per_frame and single_frame_time calculations
-- Reset-frame-time sentinel resolution
+- Reset-frame-time derivation (always equals single_frame_time)
+- Global-reset overhead methods (off / global / line_by_line)
 - First vs subsequent integration time formulas
 - Integration data and saved-frame counts (average_groups on/off)
 - update_for_vitl reset-frame adjustment
@@ -25,45 +26,66 @@ from shortschedule.nirda import NirdaData
 # ---------------------------------------------------------------------------
 # Shared test fixture — small, round-number parameters for easy hand calculation
 #
-# roi_x_size=10, roi_y_size=10, roi_x_buffer_pixels=0, roi_y_buffer_pixels=0
-# pixels_per_frame = 10 * 10 = 100
-# single_frame_time = 100 * 1e-5 s = 1e-3 s
+# roi_x_size=10, roi_y_size=10, roi_x_buffer_pixels=2, roi_y_buffer_pixels=4
+# pixels_per_frame = (10+2) * (10+4) = 168
+# single_frame_time = 168 * 1e-5 s = 1.68e-3 s
 #
 # reset_frames_1=5, reset_frames_2=1
-# drop_frames_1=0, drop_frames_2=0, drop_frames_3=0
+# drop_frames_1=1, drop_frames_2=2, drop_frames_3=3
 # read_frames=4, groups=3
 #
-# common_frames = 0 + (3-1)*0 + 0 + 3*4 = 12
-# first_integration_time  = (12 + 5) * 1e-3 = 17e-3 s
-# other_integration_time  = (12 + 1) * 1e-3 = 13e-3 s
+# common_frames = 1 + (3-1)*2 + 3 + 3*4 = 20
+# first_integration_time  = (20 + 5) * 1.68e-3 = 42.0e-3 s
+# other_integration_time  = (20 + 1) * 1.68e-3 = 35.28e-3 s
 # ---------------------------------------------------------------------------
 
 _SIMPLE = dict(
     reset_frames_1=5,
     reset_frames_2=1,
-    drop_frames_1=0,
-    drop_frames_2=0,
-    drop_frames_3=0,
+    drop_frames_1=1,
+    drop_frames_2=2,
+    drop_frames_3=3,
     read_frames=4,
     groups=3,
     average_groups=True,
     roi_x_size=10,
     roi_y_size=10,
-    roi_x_buffer_pixels=0,
-    roi_y_buffer_pixels=0,
+    roi_x_buffer_pixels=2,
+    roi_y_buffer_pixels=4,
     bytes_per_pixel=2 * u.byte,
     dropped_integrations=0,
     compression_ratio=0.8,
-    reset_frame_time=-1.0 * u.s,  # sentinel → becomes single_frame_time
+    read_time_per_pixel = 1.0e-5 * u.s,
+    global_reset_method='off',  # no per-integration global-reset overhead
     additional_overhead_time=0 * u.s,
 )
 
-_FRAME_TIME = 1e-3  # seconds, derived from _SIMPLE
-_FIRST_INT_TIME = 17e-3  # seconds
-_OTHER_INT_TIME = 13e-3  # seconds
-_PIXELS = 100
-_BYTES_PER_FRAME = 200  # bytes  (2 bytes/pixel * 100 pixels)
+# Individual fixture fields, pulled out so the derived constants and the
+# assertions below all track _SIMPLE automatically when it is edited.
+_ROI_X = _SIMPLE['roi_x_size']
+_ROI_Y = _SIMPLE['roi_y_size']
+_X_BUF = _SIMPLE['roi_x_buffer_pixels']
+_Y_BUF = _SIMPLE['roi_y_buffer_pixels']
+_RESET_1 = _SIMPLE['reset_frames_1']
+_RESET_2 = _SIMPLE['reset_frames_2']
+_DROP_1 = _SIMPLE['drop_frames_1']
+_DROP_2 = _SIMPLE['drop_frames_2']
+_DROP_3 = _SIMPLE['drop_frames_3']
+_READ_FRAMES = _SIMPLE['read_frames']
+_GROUPS = _SIMPLE['groups']
+_READ_TIME = _SIMPLE['read_time_per_pixel'].to_value(u.s)
+_BYTES_PER_PIXEL = _SIMPLE['bytes_per_pixel'].to_value(u.byte)
 
+# Derived quantities (plain floats in SI units) computed straight from the
+# fixture, mirroring NirdaData._update_derived so the maths lives in one place.
+_PIXELS = (_ROI_X + _X_BUF) * (_ROI_Y + _Y_BUF)
+_COMMON_FRAMES = (
+    _DROP_1 + (_GROUPS - 1) * _DROP_2 + _DROP_3 + _GROUPS * _READ_FRAMES
+)
+_BYTES_PER_FRAME = _PIXELS * _BYTES_PER_PIXEL
+_FRAME_TIME = _PIXELS * _READ_TIME
+_FIRST_INT_TIME = _FRAME_TIME * (_COMMON_FRAMES + _RESET_1)
+_OTHER_INT_TIME = _FRAME_TIME * (_COMMON_FRAMES + _RESET_2)
 
 def _make(**overrides):
     """Return a NirdaData built from _SIMPLE with optional field overrides."""
@@ -95,10 +117,15 @@ class TestNirdaDataDefaults:
         nd = NirdaData()
         assert nd.single_frame_time.to(u.s).value > 0
 
-    def test_default_reset_frame_time_sentinel_resolved(self):
-        """Default reset_frame_time sentinel (-1 s) should be replaced with single_frame_time."""
+    def test_default_reset_frame_time_equals_single_frame_time(self):
+        """Derived reset_frame_time should equal single_frame_time."""
         nd = NirdaData()
         assert nd.reset_frame_time == nd.single_frame_time
+
+    def test_default_global_reset_method_is_off(self):
+        """The default global_reset_method should be 'off' (no per-integration overhead)."""
+        nd = NirdaData()
+        assert nd.global_reset_method == 'off'
 
     def test_default_first_integration_time_exceeds_other(self):
         """First integration uses more reset frames so it should take longer."""
@@ -130,21 +157,23 @@ class TestPixelsPerFrame:
     def test_with_x_buffer(self):
         """x-buffer pixels are added to the column count."""
         nd = _make(roi_x_buffer_pixels=5)
-        assert nd.pixels_per_frame == (10 + 5) * 10
+        assert nd.pixels_per_frame == (_ROI_X + 5) * (_ROI_Y + _Y_BUF)
 
     def test_with_y_buffer(self):
         """y-buffer pixels are added to the row count."""
         nd = _make(roi_y_buffer_pixels=3)
-        assert nd.pixels_per_frame == 10 * (10 + 3)
+        assert nd.pixels_per_frame == (_ROI_X + _X_BUF) * (_ROI_Y + 3)
 
     def test_with_both_buffers(self):
         """Both buffers contribute independently."""
         nd = _make(roi_x_buffer_pixels=2, roi_y_buffer_pixels=2)
-        assert nd.pixels_per_frame == 12 * 12
+        assert nd.pixels_per_frame == (_ROI_X + 2) * (_ROI_Y + 2)
 
     def test_zero_roi_gives_zero(self):
-        """A zero-area ROI should yield zero pixels per frame."""
-        nd = _make(roi_x_size=0, roi_y_size=0)
+        """A zero-area ROI with no buffer pixels should yield zero pixels per frame."""
+        nd = _make(
+            roi_x_size=0, roi_y_size=0, roi_x_buffer_pixels=0, roi_y_buffer_pixels=0
+        )
         assert nd.pixels_per_frame == 0
 
 
@@ -157,7 +186,7 @@ class TestSingleFrameTime:
     def test_value(self):
         """single_frame_time should equal pixels_per_frame * read_time_per_pixel."""
         nd = _make()
-        expected = _PIXELS * 1.0e-5
+        expected = _PIXELS * _READ_TIME
         assert abs(nd.single_frame_time.to(u.s).value - expected) < 1e-15
 
     def test_units_are_seconds(self):
@@ -166,8 +195,10 @@ class TestSingleFrameTime:
         _ = nd.single_frame_time.to(u.s)  # should not raise
 
     def test_zero_pixels_zero_frame_time(self):
-        """Zero-size ROI should give zero frame time."""
-        nd = _make(roi_x_size=0, roi_y_size=0)
+        """Zero-size ROI with no buffer pixels should give zero frame time."""
+        nd = _make(
+            roi_x_size=0, roi_y_size=0, roi_x_buffer_pixels=0, roi_y_buffer_pixels=0
+        )
         assert nd.single_frame_time.to(u.s).value == 0
 
     def test_faster_clock_gives_shorter_frame(self):
@@ -182,39 +213,86 @@ class TestSingleFrameTime:
 
 
 # ---------------------------------------------------------------------------
-# Reset-frame-time sentinel
+# Reset-frame-time (derived)
 # ---------------------------------------------------------------------------
-class TestResetFrameTimeSentinel:
-    """Negative reset_frame_time should be replaced; positive should be kept."""
+class TestResetFrameTime:
+    """reset_frame_time is now a derived attribute that always tracks single_frame_time."""
 
-    def test_sentinel_becomes_single_frame_time(self):
-        """Sentinel value (-1 s) should resolve to single_frame_time."""
-        nd = _make(reset_frame_time=-1.0 * u.s)
+    def test_equals_single_frame_time(self):
+        """reset_frame_time should resolve to single_frame_time."""
+        nd = _make()
         assert nd.reset_frame_time == nd.single_frame_time
 
-    def test_explicit_positive_value_kept(self):
-        """A positive reset_frame_time should be used as-is."""
-        custom = 0.05 * u.s
-        nd = _make(reset_frame_time=custom)
-        assert nd.reset_frame_time == custom
+    def test_not_a_constructor_argument(self):
+        """reset_frame_time is init=False, so passing it should raise TypeError."""
+        with pytest.raises(TypeError):
+            _make(reset_frame_time=0.05 * u.s)
 
-    def test_explicit_zero_value_kept(self):
-        """An explicit zero reset_frame_time should remain zero."""
-        nd = _make(reset_frame_time=0.0 * u.s)
+    def test_zero_when_frame_time_zero(self):
+        """A zero-area ROI gives zero single_frame_time and therefore zero reset_frame_time."""
+        nd = _make(
+            roi_x_size=0, roi_y_size=0, roi_x_buffer_pixels=0, roi_y_buffer_pixels=0
+        )
         assert nd.reset_frame_time.to(u.s).value == 0.0
 
-    def test_sentinel_affects_integration_time(self):
-        """Changing reset_frame_time should change first_integration_time."""
-        nd_default = _make()
-        nd_custom = _make(reset_frame_time=0.1 * u.s)
-        assert nd_custom.first_integration_time != nd_default.first_integration_time
+
+# ---------------------------------------------------------------------------
+# Global-reset overhead
+# ---------------------------------------------------------------------------
+class TestGlobalReset:
+    """global_reset_method adds per-integration overhead for 'global' and 'line_by_line'."""
+
+    def test_off_adds_no_overhead(self):
+        """'off' should match the plain (common_frames + reset) * frame_time formula."""
+        nd = _make(global_reset_method='off')
+        assert abs(nd.first_integration_time.to(u.s).value - _FIRST_INT_TIME) < 1e-12
+        assert abs(nd.other_integration_time.to(u.s).value - _OTHER_INT_TIME) < 1e-12
+
+    def test_global_adds_small_fixed_overhead(self):
+        """'global' should add a small (1e-6 s) overhead to both integration times."""
+        nd_off = _make(global_reset_method='off')
+        nd_global = _make(global_reset_method='global')
+        for off, glob in (
+            (nd_off.first_integration_time, nd_global.first_integration_time),
+            (nd_off.other_integration_time, nd_global.other_integration_time),
+        ):
+            assert abs((glob - off).to(u.s).value - 1.0e-6) < 1e-15
+
+    def test_line_by_line_adds_rows_times_per_row(self):
+        """'line_by_line' overhead should equal lbl_rows * lbl_time_per_row."""
+        rows, per_row = 256, 10.0e-6 * u.s
+        nd_off = _make(global_reset_method='off')
+        nd_lbl = _make(
+            global_reset_method='line_by_line',
+            global_reset_lbl_rows=rows,
+            global_reset_lbl_time_per_row=per_row,
+        )
+        expected = (rows * per_row).to(u.s).value
+        assert abs(
+            (nd_lbl.first_integration_time - nd_off.first_integration_time).to(u.s).value
+            - expected
+        ) < 1e-15
+
+    def test_line_by_line_overhead_scales_with_rows(self):
+        """More reset rows should produce a larger line_by_line overhead."""
+        nd_few = _make(global_reset_method='line_by_line', global_reset_lbl_rows=10)
+        nd_many = _make(global_reset_method='line_by_line', global_reset_lbl_rows=500)
+        assert nd_many.first_integration_time > nd_few.first_integration_time
+
+    def test_method_is_case_and_whitespace_insensitive(self):
+        """Method strings should be normalized (lowercased and stripped)."""
+        nd = _make(global_reset_method='  GLOBAL  ')
+        assert nd.global_reset_method == 'global'
+
+    def test_unknown_method_raises(self):
+        """An unrecognized method should raise ValueError."""
+        with pytest.raises(ValueError):
+            _make(global_reset_method='nonsense')
 
 
 # ---------------------------------------------------------------------------
 # Integration time formulas
 # ---------------------------------------------------------------------------
-
-
 class TestIntegrationTimes:
     """Tests for first_integration_time and other_integration_time."""
 
@@ -309,14 +387,17 @@ class TestUpdateForVitl:
     def test_reset_frames_1_set_to_ceiling(self):
         """reset_frames_1 should be ceil(settling_time / frame_time)."""
         nd = _make()
-        settling = 7.5e-3 * u.s  # frame_time=1e-3 → ceil(7.5)=8
+        settling = 7.5 * nd.single_frame_time  # ceil(7.5) = 8
         nd.update_for_vitl(settling)
         assert nd.reset_frames_1 == 8
 
     def test_exact_multiple_no_extra_frame(self):
         """Exact multiple of frame_time should need no extra frame."""
         nd = _make()
-        settling = 5e-3 * u.s  # exactly 5 frame times
+        # A hair under five frame times so floating-point rounding cannot push
+        # the ceiling to six; still represents "an exact multiple needs no extra
+        # frame".
+        settling = (5 - 1e-9) * nd.single_frame_time
         nd.update_for_vitl(settling)
         assert nd.reset_frames_1 == 5
 
@@ -337,12 +418,18 @@ class TestUpdateForVitl:
         """Derived attributes should be updated after update_for_vitl."""
         nd = _make()
         old_first = nd.first_integration_time.to(u.s).value
-        nd.update_for_vitl(100e-3 * u.s)  # much longer settling → more resets
+        # Force a reset count well away from the fixture's reset_frames_1 so the
+        # first-integration time is guaranteed to change.
+        nd.update_for_vitl((_RESET_1 + 50) * nd.single_frame_time)
         assert nd.first_integration_time.to(u.s).value != old_first
 
     def test_zero_frame_time_gives_one_reset(self):
         """If reset_frame_time is zero update_for_vitl must not divide by zero."""
-        nd = _make(reset_frame_time=0.0 * u.s, roi_x_size=0, roi_y_size=0)
+        # A zero-area ROI drives single_frame_time (and thus reset_frame_time) to zero.
+        nd = _make(
+            roi_x_size=0, roi_y_size=0, roi_x_buffer_pixels=0, roi_y_buffer_pixels=0
+        )
+        assert nd.reset_frame_time.to(u.s).value == 0.0
         nd.update_for_vitl(10.0 * u.s)
         assert nd.reset_frames_1 == 1
 
@@ -376,24 +463,36 @@ class TestSolveIntegrations:
     def test_exact_first_integration_window(self):
         """Duration exactly equal to first_integration_time should give one integration."""
         nd = _make()
-        integrations, _, _ = nd.solve_integrations(_FIRST_INT_TIME * u.s, 0 * u.s, 0 * u.s)
+        # Use the object's own first_integration_time so the boundary is exact
+        # regardless of floating-point ordering in the derived constants.
+        integrations, _, _ = nd.solve_integrations(
+            nd.first_integration_time, 0 * u.s, 0 * u.s
+        )
         assert integrations == 1
 
     def test_multiple_integrations_count(self):
         """Duration covering multiple integrations should be counted correctly."""
         nd = _make()
-        # Use object's derived times + 1 ns guard to stay above the exact boundary
-        # without crossing into the next integration window (other_int ≈ 13 ms).
-        duration = nd.first_integration_time + nd.other_integration_time * 3 + 1e-9 * u.s
+        # Use the object's own derived times plus a tiny relative guard so we
+        # stay just above the boundary without fitting an extra integration.
+        duration = (
+            nd.first_integration_time
+            + nd.other_integration_time * 3
+            + nd.other_integration_time * 1e-6
+        )
         integrations, _, _ = nd.solve_integrations(duration, 0 * u.s, 0 * u.s)
         assert integrations == 4
 
     def test_overhead_reduces_count(self):
         """Adding overhead should reduce the number of integrations."""
         nd = _make()
-        duration = 100e-3 * u.s
+        # Window fits several integrations; a pre-overhead of two integrations'
+        # worth must remove at least one.
+        duration = (_FIRST_INT_TIME + 3 * _OTHER_INT_TIME) * u.s
         n_no_oh, _, _ = nd.solve_integrations(duration, 0 * u.s, 0 * u.s)
-        n_with_oh, _, _ = nd.solve_integrations(duration, 30e-3 * u.s, 0 * u.s)
+        n_with_oh, _, _ = nd.solve_integrations(
+            duration, _OTHER_INT_TIME * 2 * u.s, 0 * u.s
+        )
         assert n_with_oh < n_no_oh
 
     def test_data_scales_with_integrations(self):
@@ -414,7 +513,9 @@ class TestSolveIntegrations:
         """dropped_integrations should be subtracted from the raw count."""
         nd_no_drop = _make(dropped_integrations=0)
         nd_dropped = _make(dropped_integrations=2)
-        duration = 100e-3 * u.s
+        # Window comfortably fits more than two integrations so the raw count
+        # stays above the dropped count.
+        duration = (_FIRST_INT_TIME + 3 * _OTHER_INT_TIME) * u.s
         n_no, _, _ = nd_no_drop.solve_integrations(duration, 0 * u.s, 0 * u.s)
         n_drop, _, _ = nd_dropped.solve_integrations(duration, 0 * u.s, 0 * u.s)
         assert n_no - n_drop == 2
@@ -428,8 +529,10 @@ class TestSolveIntegrations:
     def test_additional_overhead_reduces_count(self):
         """additional_overhead_time should reduce the effective window."""
         nd_no_oh = _make(additional_overhead_time=0 * u.s)
-        nd_with_oh = _make(additional_overhead_time=20e-3 * u.s)
-        duration = 60e-3 * u.s
+        nd_with_oh = _make(additional_overhead_time=_OTHER_INT_TIME * u.s)
+        # Window fits two integrations; one integration's worth of additional
+        # overhead must drop the count.
+        duration = (_FIRST_INT_TIME + _OTHER_INT_TIME) * u.s + _OTHER_INT_TIME * 1e-6 * u.s
         n_no, _, _ = nd_no_oh.solve_integrations(duration, 0 * u.s, 0 * u.s)
         n_with, _, _ = nd_with_oh.solve_integrations(duration, 0 * u.s, 0 * u.s)
         assert n_with < n_no
@@ -437,7 +540,9 @@ class TestSolveIntegrations:
     def test_duration_shorter_than_first_integration_gives_zero(self):
         """If first_integration_time > duration, result should be zero."""
         nd = _make()
-        duration = (_FIRST_INT_TIME - 1e-6) * u.s
+        # Just under the object's own first_integration_time, scaled so it works
+        # at any magnitude.
+        duration = nd.first_integration_time * (1 - 1e-6)
         integrations, _, _ = nd.solve_integrations(duration, 0 * u.s, 0 * u.s)
         assert integrations == 0
 
@@ -537,6 +642,8 @@ class TestSolveRoundtrip:
         nd = _make()
         for n in range(1, 8):
             duration, _, _ = nd.solve_duration(n, 0 * u.s, 0 * u.s)
+            # Tiny relative guard against floating-point loss when re-dividing.
+            duration = duration + nd.other_integration_time * 1e-6
             recovered, _, _ = nd.solve_integrations(duration, 0 * u.s, 0 * u.s)
             assert recovered == n, f"Roundtrip failed for n={n}: recovered {recovered}"
 
@@ -546,9 +653,9 @@ class TestSolveRoundtrip:
         pre, post = 20e-3 * u.s, 10e-3 * u.s
         for n in range(1, 6):
             duration, _, _ = nd.solve_duration(n, pre, post)
-            # Add a sub-nanosecond epsilon so floating-point boundary comparisons
+            # Add a tiny relative epsilon so floating-point boundary comparisons
             # stay on the correct (>=) side without fitting an extra integration.
-            duration = duration + 1e-9 * u.s
+            duration = duration + nd.other_integration_time * 1e-6
             recovered, _, _ = nd.solve_integrations(duration, pre, post)
             assert recovered == n, (
                 f"Roundtrip with overhead failed for n={n}: recovered {recovered}"
@@ -565,3 +672,99 @@ class TestSolveRoundtrip:
         duration, _, _ = nd.solve_duration(n_total, 0 * u.s, 0 * u.s)
         recovered, _, _ = nd.solve_integrations(duration, 0 * u.s, 0 * u.s)
         assert recovered == n_science
+
+
+# ---------------------------------------------------------------------------
+# bytes_per_pixel scaling
+# ---------------------------------------------------------------------------
+class TestBytesPerPixel:
+    """integration_data should scale linearly with bytes_per_pixel."""
+
+    def test_data_scales_with_bytes_per_pixel(self):
+        """Doubling bytes_per_pixel should double integration_data."""
+        nd_2 = _make(bytes_per_pixel=2 * u.byte)
+        nd_4 = _make(bytes_per_pixel=4 * u.byte)
+        assert abs(
+            nd_4.integration_data.to(u.byte).value
+            - 2 * nd_2.integration_data.to(u.byte).value
+        ) < 1e-10
+
+    def test_explicit_value_matches_pixels_times_groups(self):
+        """integration_data (averaged) == bytes_per_pixel * pixels * groups."""
+        nd = _make(bytes_per_pixel=3 * u.byte, average_groups=True)
+        expected = 3 * _PIXELS * nd.groups
+        assert abs(nd.integration_data.to(u.byte).value - expected) < 1e-10
+
+    def test_zero_bytes_per_pixel_gives_zero_data(self):
+        """Zero bytes per pixel should yield zero integration data."""
+        nd = _make(bytes_per_pixel=0 * u.byte)
+        assert nd.integration_data.to(u.byte).value == 0
+
+
+# ---------------------------------------------------------------------------
+# ROI start coordinates are metadata only
+# ---------------------------------------------------------------------------
+class TestRoiStartIsMetadata:
+    """roi_x_start / roi_y_start are stored but must not affect derived values."""
+
+    def test_roi_start_stored_as_given(self):
+        """roi_x_start and roi_y_start should be stored verbatim."""
+        nd = _make(roi_x_start=1234, roi_y_start=5678)
+        assert nd.roi_x_start == 1234
+        assert nd.roi_y_start == 5678
+
+    def test_roi_start_does_not_change_derived_values(self):
+        """Changing the ROI start should leave timing and data untouched."""
+        nd_a = _make(roi_x_start=0, roi_y_start=0)
+        nd_b = _make(roi_x_start=1737, roi_y_start=962)
+        assert nd_a.pixels_per_frame == nd_b.pixels_per_frame
+        assert nd_a.single_frame_time == nd_b.single_frame_time
+        assert nd_a.first_integration_time == nd_b.first_integration_time
+        assert nd_a.integration_data == nd_b.integration_data
+
+
+# ---------------------------------------------------------------------------
+# Negative-input clamping
+# ---------------------------------------------------------------------------
+class TestNegativeInputClamping:
+    """Negative frame inputs should clamp to zero, never produce negatives."""
+
+    def test_negative_drop_frames_clamp_common_frames(self):
+        """A large negative drop_frames_1 should floor integration time at zero."""
+        nd = _make(
+            reset_frames_1=0,
+            reset_frames_2=0,
+            read_frames=0,
+            groups=1,
+            drop_frames_1=-100,
+        )
+        assert nd.first_integration_time.to(u.s).value == 0
+        assert nd.other_integration_time.to(u.s).value == 0
+
+    def test_negative_drop_frames_still_nonnegative_data(self):
+        """Negative drop frames must not drive integration_data negative."""
+        nd = _make(drop_frames_1=-50)
+        assert nd.integration_data.to(u.byte).value >= 0
+
+
+# ---------------------------------------------------------------------------
+# additional_overhead_time in solve_duration
+# ---------------------------------------------------------------------------
+class TestAdditionalOverheadInSolveDuration:
+    """additional_overhead_time should be folded into solve_duration's overhead."""
+
+    def test_additional_overhead_added_to_duration(self):
+        """solve_duration should add additional_overhead_time to the total."""
+        nd_no_oh = _make(additional_overhead_time=0 * u.s)
+        nd_with_oh = _make(additional_overhead_time=5e-3 * u.s)
+        dur_no, _, _ = nd_no_oh.solve_duration(3, 0 * u.s, 0 * u.s)
+        dur_with, _, _ = nd_with_oh.solve_duration(3, 0 * u.s, 0 * u.s)
+        assert abs(
+            dur_with.to(u.s).value - dur_no.to(u.s).value - 5e-3
+        ) < 1e-12
+
+    def test_additional_overhead_not_added_when_zero_integrations(self):
+        """Zero integrations should give zero duration regardless of overhead."""
+        nd = _make(additional_overhead_time=5e-3 * u.s)
+        duration, _, _ = nd.solve_duration(0, 0 * u.s, 0 * u.s)
+        assert duration.to(u.s).value == 0.0

--- a/tests/test_nirda.py
+++ b/tests/test_nirda.py
@@ -36,8 +36,10 @@ def _nirda_overhead(pre=0 * u.s, post=0 * u.s):
 # Shared test fixture — small, round-number parameters for easy hand calculation
 #
 # roi_x_size=10, roi_y_size=10, roi_x_buffer_pixels=2, roi_y_buffer_pixels=4
-# pixels_per_frame = (10+2) * (10+4) = 168
+# pixels_per_frame = (10+2) * (10+4) = 168   (buffer pixels cost read time)
 # single_frame_time = 168 * 1e-5 s = 1.68e-3 s
+#
+# saved_pixels_per_frame = 10 * 10 = 100     (buffer pixels are not saved)
 #
 # reset_frames_1=5, reset_frames_2=1
 # drop_frames_1=1, drop_frames_2=2, drop_frames_3=3
@@ -88,10 +90,12 @@ _BYTES_PER_PIXEL = _SIMPLE['bytes_per_pixel'].to_value(u.byte)
 # Derived quantities (plain floats in SI units) computed straight from the
 # fixture, mirroring NirdaData._update_derived so the maths lives in one place.
 _PIXELS = (_ROI_X + _X_BUF) * (_ROI_Y + _Y_BUF)
+# Buffer pixels are clocked out (frame time) but never saved (data volume).
+_SAVED_PIXELS = _ROI_X * _ROI_Y
 _COMMON_FRAMES = (
     _DROP_1 + (_GROUPS - 1) * _DROP_2 + _DROP_3 + _GROUPS * _READ_FRAMES
 )
-_BYTES_PER_FRAME = _PIXELS * _BYTES_PER_PIXEL
+_BYTES_PER_FRAME = _SAVED_PIXELS * _BYTES_PER_PIXEL
 _FRAME_TIME = _PIXELS * _READ_TIME
 _FIRST_INT_TIME = _FRAME_TIME * (_COMMON_FRAMES + _RESET_1)
 _OTHER_INT_TIME = _FRAME_TIME * (_COMMON_FRAMES + _RESET_2)
@@ -184,6 +188,38 @@ class TestPixelsPerFrame:
             roi_x_size=0, roi_y_size=0, roi_x_buffer_pixels=0, roi_y_buffer_pixels=0
         )
         assert nd.pixels_per_frame == 0
+
+
+# ---------------------------------------------------------------------------
+# saved_pixels_per_frame
+# ---------------------------------------------------------------------------
+class TestSavedPixelsPerFrame:
+    """Buffer pixels are read out but not saved, so they never reach downlink."""
+
+    def test_excludes_buffer_pixels(self):
+        """saved_pixels_per_frame is the science ROI only."""
+        nd = _make()
+        assert nd.saved_pixels_per_frame == _SAVED_PIXELS
+        assert nd.saved_pixels_per_frame < nd.pixels_per_frame
+
+    def test_buffer_pixels_do_not_change_data_volume(self):
+        """Changing either buffer must leave integration_data untouched."""
+        nd_base = _make()
+        nd_big_buf = _make(roi_x_buffer_pixels=100, roi_y_buffer_pixels=50)
+        assert nd_big_buf.integration_data == nd_base.integration_data
+
+    def test_buffer_pixels_still_change_frame_time(self):
+        """Buffer pixels must still lengthen the frame (and integration) time."""
+        nd_base = _make()
+        nd_big_buf = _make(roi_x_buffer_pixels=100, roi_y_buffer_pixels=50)
+        assert nd_big_buf.single_frame_time > nd_base.single_frame_time
+        assert nd_big_buf.first_integration_time > nd_base.first_integration_time
+
+    def test_zero_roi_gives_zero(self):
+        """A zero-area ROI saves no pixels, even with buffer pixels present."""
+        nd = _make(roi_x_size=0, roi_y_size=0)
+        assert nd.saved_pixels_per_frame == 0
+        assert nd.integration_data.to(u.byte).value == 0
 
 
 # ---------------------------------------------------------------------------
@@ -703,9 +739,9 @@ class TestBytesPerPixel:
         ) < 1e-10
 
     def test_explicit_value_matches_pixels_times_groups(self):
-        """integration_data (averaged) == bytes_per_pixel * pixels * groups."""
+        """integration_data (averaged) == bytes_per_pixel * saved pixels * groups."""
         nd = _make(bytes_per_pixel=3 * u.byte, average_groups=True)
-        expected = 3 * _PIXELS * nd.groups
+        expected = 3 * _SAVED_PIXELS * nd.groups
         assert abs(nd.integration_data.to(u.byte).value - expected) < 1e-10
 
     def test_zero_bytes_per_pixel_gives_zero_data(self):

--- a/tests/test_overhead.py
+++ b/tests/test_overhead.py
@@ -1,0 +1,148 @@
+"""Unit tests for the OverheadTiming class in shortschedule.overhead.
+
+Tests cover:
+- Default construction and that all four overhead times are populated
+- Default values match the modelled MOC command sequence
+- VISDA pre-overhead is larger than NIRDA pre-overhead (extra acquire offset)
+- NIRDA and VISDA post-overheads are equal
+- Units are seconds
+- Explicit values override the derived defaults
+- Partial overrides leave the other fields at their defaults
+"""
+
+# Third-party
+import pytest
+from astropy import units as u
+
+# First-party/Local
+from shortschedule.overhead import OverheadTiming
+
+# ---------------------------------------------------------------------------
+# Expected defaults, computed straight from the modelled command sequence in
+# OverheadTiming._update_derived so the maths lives in one place.
+#
+# Pre-observation:
+#   GOTO_TARGET                          +2.0
+#   MACRO_EXECUTE 65                     +20.0
+#   PAYLOAD_READ                         +186.0
+#   SADA_MODE 1 INDEX STOP               +50.0
+#   -> NIRDA pre-overhead snapshot       = 258.0
+#   PAYLOAD_ACQUIRE_INF_CAM_IMAGES       +2.0
+#   -> VISDA pre-overhead snapshot       = 260.0
+#
+# Post-observation:
+#   PAYLOAD_HALT_IMAGING_OR_COMMAND_SEQ  +2.0
+#   SADA_MODE 1 INDEX AUTO_TRACK_QEST    +40.0
+#   GOTO_TARGET Idle                     +18.0
+#   PAYLOAD_READ close file              +42.0
+#   -> NIRDA/VISDA post-overhead         = 102.0
+# ---------------------------------------------------------------------------
+_NIRDA_PRE = 258.0
+_VISDA_PRE = 260.0
+_POST = 102.0
+
+
+# ---------------------------------------------------------------------------
+# Default construction
+# ---------------------------------------------------------------------------
+class TestOverheadTimingDefaults:
+    """OverheadTiming() with no arguments should populate all four times."""
+
+    def test_default_construction_succeeds(self):
+        """OverheadTiming with no arguments should not raise."""
+        oh = OverheadTiming()
+        assert oh is not None
+
+    def test_all_fields_populated(self):
+        """All four overhead times should be filled in (not None)."""
+        oh = OverheadTiming()
+        assert oh.nirda_pre_overhead_time is not None
+        assert oh.visda_pre_overhead_time is not None
+        assert oh.nirda_post_overhead_time is not None
+        assert oh.visda_post_overhead_time is not None
+
+    def test_nirda_pre_overhead_value(self):
+        """NIRDA pre-overhead should match the modelled command sequence."""
+        oh = OverheadTiming()
+        assert abs(oh.nirda_pre_overhead_time.to(u.s).value - _NIRDA_PRE) < 1e-12
+
+    def test_visda_pre_overhead_value(self):
+        """VISDA pre-overhead should match the modelled command sequence."""
+        oh = OverheadTiming()
+        assert abs(oh.visda_pre_overhead_time.to(u.s).value - _VISDA_PRE) < 1e-12
+
+    def test_post_overhead_value(self):
+        """Post-overheads should match the modelled command sequence."""
+        oh = OverheadTiming()
+        assert abs(oh.nirda_post_overhead_time.to(u.s).value - _POST) < 1e-12
+        assert abs(oh.visda_post_overhead_time.to(u.s).value - _POST) < 1e-12
+
+    def test_units_are_seconds(self):
+        """Every derived overhead should be convertible to seconds."""
+        oh = OverheadTiming()
+        for q in (
+            oh.nirda_pre_overhead_time,
+            oh.visda_pre_overhead_time,
+            oh.nirda_post_overhead_time,
+            oh.visda_post_overhead_time,
+        ):
+            _ = q.to(u.s)  # should not raise
+
+
+# ---------------------------------------------------------------------------
+# Relationships between the default overheads
+# ---------------------------------------------------------------------------
+class TestOverheadRelationships:
+    """The derived overheads should hold the expected relative ordering."""
+
+    def test_visda_pre_exceeds_nirda_pre(self):
+        """VISDA pre-overhead carries an extra acquire offset over NIRDA."""
+        oh = OverheadTiming()
+        assert oh.visda_pre_overhead_time > oh.nirda_pre_overhead_time
+
+    def test_post_overheads_equal(self):
+        """NIRDA and VISDA share the same post-overhead."""
+        oh = OverheadTiming()
+        assert oh.nirda_post_overhead_time == oh.visda_post_overhead_time
+
+    def test_all_overheads_positive(self):
+        """All derived overheads should be strictly positive."""
+        oh = OverheadTiming()
+        assert oh.nirda_pre_overhead_time.to(u.s).value > 0
+        assert oh.visda_pre_overhead_time.to(u.s).value > 0
+        assert oh.nirda_post_overhead_time.to(u.s).value > 0
+        assert oh.visda_post_overhead_time.to(u.s).value > 0
+
+
+# ---------------------------------------------------------------------------
+# Explicit overrides
+# ---------------------------------------------------------------------------
+class TestOverheadOverrides:
+    """Explicit Quantity values should override the derived defaults."""
+
+    def test_all_overrides_respected(self):
+        """Supplying all four values should leave them untouched."""
+        oh = OverheadTiming(
+            nirda_pre_overhead_time=1.0 * u.s,
+            visda_pre_overhead_time=2.0 * u.s,
+            nirda_post_overhead_time=3.0 * u.s,
+            visda_post_overhead_time=4.0 * u.s,
+        )
+        assert oh.nirda_pre_overhead_time.to(u.s).value == 1.0
+        assert oh.visda_pre_overhead_time.to(u.s).value == 2.0
+        assert oh.nirda_post_overhead_time.to(u.s).value == 3.0
+        assert oh.visda_post_overhead_time.to(u.s).value == 4.0
+
+    def test_partial_override_fills_remaining_defaults(self):
+        """An overridden field stays; unset fields fall back to defaults."""
+        oh = OverheadTiming(nirda_pre_overhead_time=5.0 * u.s)
+        assert oh.nirda_pre_overhead_time.to(u.s).value == 5.0
+        # The others should still be derived.
+        assert abs(oh.visda_pre_overhead_time.to(u.s).value - _VISDA_PRE) < 1e-12
+        assert abs(oh.nirda_post_overhead_time.to(u.s).value - _POST) < 1e-12
+        assert abs(oh.visda_post_overhead_time.to(u.s).value - _POST) < 1e-12
+
+    def test_zero_override_is_kept(self):
+        """A zero override should be honoured, not replaced by the default."""
+        oh = OverheadTiming(nirda_pre_overhead_time=0.0 * u.s)
+        assert oh.nirda_pre_overhead_time.to(u.s).value == 0.0

--- a/tests/test_payload_overrides.py
+++ b/tests/test_payload_overrides.py
@@ -189,6 +189,74 @@ class TestObservationalParameterOverride:
         assert local(payload, "Observational_Parameters") is None
 
 
+class TestSingleRoiConversion:
+    """Convert single-ROI auto-detect VIS sections to predefined-ROI."""
+
+    def _sched(self):
+        sched = ScheduleProcessor.__new__(ScheduleProcessor)
+        sched.convert_single_roi_to_predefined = True
+        return sched
+
+    def _seq_single_auto(self, **vis_extra):
+        seq = _seq(priority=0)
+        vis = seq.payload_params[VisdaData.PAYLOAD_SECTION]
+        for tag in ("MaxNumStarRois", "StarRoiDetMethod"):
+            existing = vis.find(tag)
+            if existing is None:
+                existing = ET.SubElement(vis, tag)
+        vis.find("MaxNumStarRois").text = "1"
+        vis.find("StarRoiDetMethod").text = "2"
+        for tag, value in vis_extra.items():
+            elem = vis.find(tag)
+            if elem is None:
+                elem = ET.SubElement(vis, tag)
+            elem.text = str(value)
+        return seq
+
+    def test_converts_to_predefined(self):
+        seq = self._seq_single_auto()
+        assert self._sched()._convert_single_roi_to_predefined(seq) is True
+        vis = seq.payload_params[VisdaData.PAYLOAD_SECTION]
+        assert vis.find("StarRoiDetMethod").text == "1"
+        assert vis.find("numPredefinedStarRois").text == "1"
+        # RA/Dec come from the sequence's own coordinates (10.0/20.0).
+        assert vis.find("PredefinedStarRoiRa").find("RA1").text == "10"
+        assert vis.find("PredefinedStarRoiDec").find("Dec1").text == "20"
+
+    def test_prefers_target_radec_verbatim(self):
+        seq = self._seq_single_auto(TargetRA="123.456", TargetDEC="-7.89")
+        assert self._sched()._convert_single_roi_to_predefined(seq) is True
+        vis = seq.payload_params[VisdaData.PAYLOAD_SECTION]
+        assert vis.find("PredefinedStarRoiRa").find("RA1").text == "123.456"
+        assert vis.find("PredefinedStarRoiDec").find("Dec1").text == "-7.89"
+
+    def test_idempotent_when_already_predefined(self):
+        seq = self._seq_single_auto()
+        sched = self._sched()
+        assert sched._convert_single_roi_to_predefined(seq) is True
+        # A second pass finds RA1/Dec1 already present and StarRoiDetMethod 1.
+        assert sched._convert_single_roi_to_predefined(seq) is False
+
+    def test_skips_non_single_roi(self):
+        seq = self._seq_single_auto()
+        seq.payload_params[VisdaData.PAYLOAD_SECTION].find(
+            "MaxNumStarRois"
+        ).text = "9"
+        assert self._sched()._convert_single_roi_to_predefined(seq) is False
+
+    def test_skips_non_autodetect_method(self):
+        seq = self._seq_single_auto()
+        seq.payload_params[VisdaData.PAYLOAD_SECTION].find(
+            "StarRoiDetMethod"
+        ).text = "1"
+        assert self._sched()._convert_single_roi_to_predefined(seq) is False
+
+    def test_skips_free_time(self):
+        seq = self._seq_single_auto()
+        seq.target = "Free Time"
+        assert self._sched()._convert_single_roi_to_predefined(seq) is False
+
+
 class TestNormalizePriorityKeys:
     def test_int_and_string_keys(self):
         norm = ScheduleProcessor._normalize_priority_keys(

--- a/tests/test_payload_overrides.py
+++ b/tests/test_payload_overrides.py
@@ -257,6 +257,52 @@ class TestSingleRoiConversion:
         assert self._sched()._convert_single_roi_to_predefined(seq) is False
 
 
+class TestFixBadData:
+    """Replace invalid name symbols and flag NaN-like field values."""
+
+    def _sched(self):
+        sched = ScheduleProcessor.__new__(ScheduleProcessor)
+        sched.fix_bad_data = True
+        sched.logger = None
+        return sched
+
+    def test_replaces_plus_in_target_attribute(self):
+        seq = _seq(target="WASP+12b")
+        self._sched()._fix_bad_data(seq)
+        assert seq.target == "WASP_12b"
+
+    def test_replaces_plus_in_target_payload_tags(self):
+        seq = _seq()
+        vis = seq.payload_params[VisdaData.PAYLOAD_SECTION]
+        ET.SubElement(vis, "TargetID").text = "TOI+674b"
+        self._sched()._fix_bad_data(seq)
+        assert vis.find("TargetID").text == "TOI_674b"
+
+    def test_nan_in_numeric_field_warns(self, capsys):
+        seq = _seq()
+        seq.payload_params[VisdaData.PAYLOAD_SECTION].find(
+            "FramesPerCoadd"
+        ).text = "nan"
+        self._sched()._fix_bad_data(seq)
+        out = capsys.readouterr().out
+        assert "NaN-like value" in out and "FramesPerCoadd" in out
+
+    def test_nan_in_name_field_not_flagged(self, capsys):
+        seq = _seq()
+        vis = seq.payload_params[VisdaData.PAYLOAD_SECTION]
+        ET.SubElement(vis, "TargetID").text = "nan"
+        self._sched()._fix_bad_data(seq)
+        assert "NaN-like value" not in capsys.readouterr().out
+
+    def test_free_time_nan_skipped(self, capsys):
+        seq = _seq(target="Free Time")
+        seq.payload_params[VisdaData.PAYLOAD_SECTION].find(
+            "FramesPerCoadd"
+        ).text = "nan"
+        self._sched()._fix_bad_data(seq)
+        assert "NaN-like value" not in capsys.readouterr().out
+
+
 class TestNormalizePriorityKeys:
     def test_int_and_string_keys(self):
         norm = ScheduleProcessor._normalize_priority_keys(

--- a/tests/test_payload_overrides.py
+++ b/tests/test_payload_overrides.py
@@ -1,0 +1,276 @@
+"""Tests for general per-priority XML-tag payload overrides.
+
+Covers ScheduleProcessor(override_payload_parameters=...):
+- Existing payload tags are overwritten by priority
+- Missing tags are created
+- Priority routing (int and 'Priority_N' string keys)
+- Free-time observations are skipped
+- Overrides applied before integration recompute (size/coadd/reset flow
+  through to SC_Integrations / NumTotalFramesRequested)
+"""
+
+# Standard library
+import unittest.mock as mock
+import xml.etree.ElementTree as ET
+
+# Third-party
+from astropy import units as u
+from astropy.time import Time, TimeDelta
+
+# First-party/Local
+from shortschedule.models import ObservationSequence
+from shortschedule.nirda import NirdaData
+from shortschedule.scheduler import ScheduleProcessor
+from shortschedule.visda import VisdaData
+
+
+def _nir_payload(**tags):
+    root = ET.Element(NirdaData.PAYLOAD_SECTION)
+    cfg = NirdaData().get_config()
+    for field, (tag, _from, to_xml) in NirdaData.CONFIG_SPEC.items():
+        ET.SubElement(root, tag).text = to_xml(cfg[field])
+    ET.SubElement(root, "SC_Integrations").text = "0"
+    for tag, value in tags.items():
+        existing = root.find(tag)
+        if existing is None:
+            existing = ET.SubElement(root, tag)
+        existing.text = str(value)
+    return root
+
+
+def _vis_payload(**tags):
+    root = ET.Element(VisdaData.PAYLOAD_SECTION)
+    cfg = VisdaData().get_config()
+    for field, (tag, _from, to_xml) in VisdaData.CONFIG_SPEC.items():
+        ET.SubElement(root, tag).text = to_xml(cfg[field])
+    ET.SubElement(root, "NumTotalFramesRequested").text = "0"
+    for tag, value in tags.items():
+        existing = root.find(tag)
+        if existing is None:
+            existing = ET.SubElement(root, tag)
+        existing.text = str(value)
+    return root
+
+
+def _seq(priority=0, target="TargetA", dur_min=60):
+    start = Time("2026-03-01T00:00:00", scale="utc")
+    return ObservationSequence(
+        id="001",
+        target=target,
+        priority=priority,
+        start_time=start,
+        stop_time=start + TimeDelta(dur_min * 60, format="sec"),
+        ra=10.0,
+        dec=20.0,
+        payload_params={
+            NirdaData.PAYLOAD_SECTION: _nir_payload(ROI_SizeX=999),
+            VisdaData.PAYLOAD_SECTION: _vis_payload(FramesPerCoadd=3),
+        },
+    )
+
+
+def _bare_sched(overrides):
+    sched = ScheduleProcessor.__new__(ScheduleProcessor)
+    sched._override_payload_parameters = (
+        ScheduleProcessor._normalize_priority_keys(overrides)
+    )
+    return sched
+
+
+class TestApplyPayloadOverrides:
+    def test_existing_tag_overwritten(self):
+        seq = _seq(priority=0)
+        sched = _bare_sched(
+            {0: {"AcquireInfCamImages": {"ROI_SizeX": 80}}}
+        )
+        sched._apply_payload_overrides(seq)
+        assert (
+            seq.get_payload_parameter("AcquireInfCamImages", "ROI_SizeX")
+            == "80"
+        )
+
+    def test_missing_tag_created(self):
+        seq = _seq(priority=0)
+        # ROI_StartX is not present in the default NIR payload.
+        assert (
+            seq.get_payload_parameter("AcquireInfCamImages", "ROI_StartX")
+            is None
+        )
+        sched = _bare_sched(
+            {0: {"AcquireInfCamImages": {"ROI_StartX": 1737}}}
+        )
+        sched._apply_payload_overrides(seq)
+        assert (
+            seq.get_payload_parameter("AcquireInfCamImages", "ROI_StartX")
+            == "1737"
+        )
+
+    def test_priority_string_key(self):
+        seq = _seq(priority=1)
+        sched = _bare_sched(
+            {"Priority_1": {"AcquireVisCamScienceData": {"FramesPerCoadd": 5}}}
+        )
+        sched._apply_payload_overrides(seq)
+        assert (
+            seq.get_payload_parameter(
+                "AcquireVisCamScienceData", "FramesPerCoadd"
+            )
+            == "5"
+        )
+
+    def test_non_matching_priority_untouched(self):
+        seq = _seq(priority=2)
+        sched = _bare_sched(
+            {0: {"AcquireInfCamImages": {"ROI_SizeX": 80}}}
+        )
+        sched._apply_payload_overrides(seq)
+        assert (
+            seq.get_payload_parameter("AcquireInfCamImages", "ROI_SizeX")
+            == "999"
+        )
+
+    def test_free_time_skipped(self):
+        seq = _seq(priority=0, target="Free Time")
+        sched = _bare_sched(
+            {0: {"AcquireInfCamImages": {"ROI_SizeX": 80}}}
+        )
+        sched._apply_payload_overrides(seq)
+        assert (
+            seq.get_payload_parameter("AcquireInfCamImages", "ROI_SizeX")
+            == "999"
+        )
+
+
+class TestObservationalParameterOverride:
+    """Nested Observational_Parameters overrides reach the written XML."""
+
+    def test_boresight_override_stored_nested(self):
+        seq = _seq(priority=0)
+        sched = _bare_sched(
+            {0: {"Observational_Parameters": {"Boresight": {
+                "PRI_CMD_DIR": 9}}}}
+        )
+        sched._apply_payload_overrides(seq)
+        obs = seq.payload_params["Observational_Parameters"]
+        bore = obs.find("Boresight")
+        assert bore is not None
+        assert bore.find("PRI_CMD_DIR").text == "9"
+
+    def test_override_written_to_xml(self, tmp_path):
+        """A non-default PRI_CMD_DIR override appears in the output XML."""
+        from shortschedule.models import ScienceCalendar, Visit
+        from shortschedule.writer import XMLWriter
+
+        seq = _seq(priority=0)
+        sched = _bare_sched(
+            {0: {"Observational_Parameters": {"Boresight": {
+                "PRI_CMD_DIR": 7}}}}
+        )
+        sched._apply_payload_overrides(seq)
+        cal = ScienceCalendar(metadata={}, visits=[Visit("0001", [seq])])
+        out = tmp_path / "obs.xml"
+        XMLWriter().write_calendar(cal, str(out))
+
+        root = ET.parse(str(out)).getroot()
+
+        def local(elem, name):
+            return next(
+                (c for c in elem if c.tag.endswith(name)), None
+            )
+
+        visit = local(root, "Visit")
+        obs_seq = local(visit, "Observation_Sequence")
+        obs_params = local(obs_seq, "Observational_Parameters")
+        boresight = local(obs_params, "Boresight")
+        pri = local(boresight, "PRI_CMD_DIR")
+        assert pri is not None and pri.text == "7"
+        # The override block must NOT leak into Payload_Parameters.
+        payload = local(obs_seq, "Payload_Parameters")
+        assert local(payload, "Observational_Parameters") is None
+
+
+class TestNormalizePriorityKeys:
+    def test_int_and_string_keys(self):
+        norm = ScheduleProcessor._normalize_priority_keys(
+            {0: {"a": 1}, "Priority_1": {"b": 2}, "2": {"c": 3}}
+        )
+        assert set(norm.keys()) == {0, 1, 2}
+
+    def test_empty(self):
+        assert ScheduleProcessor._normalize_priority_keys(None) == {}
+
+
+class TestPayloadOverrideThroughConstructor:
+    def test_constructor_stores_normalized(self):
+        with mock.patch("shortschedule.scheduler.Visibility"):
+            proc = ScheduleProcessor(
+                "L1",
+                "L2",
+                override_payload_parameters={
+                    "Priority_0": {"AcquireInfCamImages": {"ROI_SizeX": 80}}
+                },
+            )
+        assert 0 in proc._override_payload_parameters
+
+    def _nir_seq_big_roi(self):
+        """A NIR sequence with a huge ROI (slow frames -> few integrations)."""
+        start = Time("2026-03-01T00:00:00", scale="utc")
+        return ObservationSequence(
+            id="001",
+            target="T",
+            priority=0,
+            start_time=start,
+            stop_time=start + TimeDelta(3600, format="sec"),
+            ra=1.0,
+            dec=2.0,
+            payload_params={
+                NirdaData.PAYLOAD_SECTION: _nir_payload(
+                    ROI_SizeX=2000, ROI_SizeY=2000
+                ),
+                VisdaData.PAYLOAD_SECTION: _vis_payload(FramesPerCoadd=1),
+            },
+        )
+
+    def _run(self, overrides):
+        sched = ScheduleProcessor.__new__(ScheduleProcessor)
+        sched._override_payload_parameters = (
+            ScheduleProcessor._normalize_priority_keys(overrides or {})
+        )
+        sched._override_nirda_parameters = {}
+        sched._override_visda_parameters = {}
+        sched.overhead = None  # _update_* falls back to OverheadTiming()
+        out = sched._update_payload_parameters_sequence(
+            self._nir_seq_big_roi(), visit_id="1"
+        )
+        return (
+            out.get_payload_parameter("AcquireInfCamImages", "ROI_SizeX"),
+            int(
+                out.get_payload_parameter(
+                    "AcquireInfCamImages", "SC_Integrations"
+                )
+            ),
+            int(
+                out.get_payload_parameter(
+                    "AcquireVisCamScienceData", "NumTotalFramesRequested"
+                )
+            ),
+        )
+
+    def test_override_flows_into_integration_recompute(self):
+        """ROI/coadd overrides change the recomputed timing and data sizes."""
+        roi_no, sc_no, _ = self._run(None)
+        roi_ov, sc_ov, ntf_ov = self._run(
+            {
+                0: {
+                    "AcquireInfCamImages": {"ROI_SizeX": 80, "ROI_SizeY": 250},
+                    "AcquireVisCamScienceData": {"FramesPerCoadd": 50},
+                }
+            }
+        )
+        # The override changed the ROI used by the data class...
+        assert roi_no == "2000"
+        assert roi_ov == "80"
+        # ...which makes each NIR frame faster, fitting more integrations.
+        assert sc_ov > sc_no
+        # ...and the VIS frame count is floored to the new coadd multiple.
+        assert ntf_ov % 50 == 0

--- a/tests/test_processor_with_mock_visibility.py
+++ b/tests/test_processor_with_mock_visibility.py
@@ -1,3 +1,6 @@
+# Standard library
+from pathlib import Path
+
 # Third-party
 import numpy as np
 
@@ -28,8 +31,11 @@ def test_process_calendar_with_mocked_visibility(monkeypatch, tmp_path):
     )
 
     # Load sample calendar
-    pkgdir = shortschedule.__file__.rsplit("/", 1)[0]
-    sample = pkgdir + "/data/Pandora_science_calendar_20251018_tsb-futz.xml"
+    sample = (
+        Path(shortschedule.__file__).parent
+        / "data"
+        / "Pandora_science_calendar_20251018_tsb-futz.xml"
+    )
 
     cal = parse_science_calendar(sample)
     assert len(cal.visits) > 0

--- a/tests/test_processor_with_mock_visibility.py
+++ b/tests/test_processor_with_mock_visibility.py
@@ -48,7 +48,11 @@ def test_process_calendar_with_mocked_visibility(monkeypatch, tmp_path):
     sched = ScheduleProcessor("LINE1", "LINE2")
 
     processed = sched.process_calendar(
-        cal, window_start=window_start, window_duration_days=1, verbose=False
+        cal,
+        window_start=window_start,
+        window_duration_days=1,
+        log_path=tmp_path / "run",
+        verbose=False,
     )
 
     # Basic assertions: processed_calendar object and gap_report present

--- a/tests/test_roll_name_normalization.py
+++ b/tests/test_roll_name_normalization.py
@@ -1,0 +1,102 @@
+"""Regression test: target-name normalization must not orphan swept rolls.
+
+The roll sweep keys its results by target name. The ``fix_bad_data`` feature
+rewrites invalid name symbols (``+`` and space -> ``_``). If that rename runs
+*after* the sweep, a renamed target's swept roll is lost and the scheduler
+falls back to the continuous sun-derived roll. ``process_calendar`` therefore
+normalizes target names up front (before the sweep). These tests pin that:
+
+- a ``+``/space target keeps a *quantized* (swept) roll, not a continuous
+  sun-derived fallback;
+- the target name is normalized in the output.
+"""
+
+# Standard library
+from pathlib import Path
+
+# Third-party
+import numpy as np
+
+# First-party/Local
+import shortschedule
+from shortschedule.parser import parse_science_calendar
+from shortschedule.scheduler import ScheduleProcessor
+
+
+class DummyVisibilityAllTrue:
+    def __init__(self, l1, l2, **kwargs):
+        pass
+
+    def get_visibility(self, coord, times, roll=None):
+        try:
+            length = len(times)
+        except Exception:
+            return np.array([True], dtype=bool)
+        return np.ones(length, dtype=bool)
+
+
+def _load_sample():
+    sample = (
+        Path(shortschedule.__file__).parent
+        / "data"
+        / "Pandora_science_calendar_20251018_tsb-futz.xml"
+    )
+    return parse_science_calendar(sample)
+
+
+def test_plus_space_target_keeps_swept_roll(monkeypatch, tmp_path):
+    monkeypatch.setattr(
+        "shortschedule.scheduler.Visibility", DummyVisibilityAllTrue
+    )
+
+    cal = _load_sample()
+    # Inject a target name carrying both a '+' and a space.
+    bad_name = "BD+99 9999"
+    first = cal.visits[0].sequences[0]
+    for seq in cal.visits[0].sequences:
+        if seq.target == first.target:
+            seq.target = bad_name
+    window_start = cal.visits[0].sequences[0].start_time.isot
+
+    # Star-tracker constraints enable the roll sweep; fix_bad_data is on by
+    # default. roll_step=1.0 => swept rolls are whole degrees.
+    sched = ScheduleProcessor(
+        "LINE1",
+        "LINE2",
+        st_sun_min=50,
+        st_moon_min=20,
+        st_earthlimb_min=30,
+        roll_step=1.0,
+        min_power_frac=0.0,
+    )
+    processed = sched.process_calendar(
+        cal,
+        window_start=window_start,
+        window_duration_days=1,
+        log_path=tmp_path / "run",
+        verbose=False,
+    )
+
+    # The renamed target should appear normalized (no '+' or space).
+    normalized = "BD_99_9999"
+    matches = [
+        seq
+        for visit in processed.visits
+        for seq in visit.sequences
+        if seq.target == normalized
+    ]
+    assert matches, "normalized target name not found in output"
+    assert not any(
+        seq.target == bad_name
+        for visit in processed.visits
+        for seq in visit.sequences
+    )
+
+    # Its roll must be a swept (integer) value, not the continuous
+    # sun-derived fallback that a post-rename orphaning would produce.
+    for seq in matches:
+        assert seq.roll is not None
+        assert abs(seq.roll - round(seq.roll)) < 1e-9, (
+            f"target {seq.target} fell back to a continuous roll "
+            f"{seq.roll!r} instead of keeping its swept (integer) roll"
+        )

--- a/tests/test_visda.py
+++ b/tests/test_visda.py
@@ -1,0 +1,460 @@
+"""Unit tests for the VisdaData class in shortschedule.data.visda.
+
+Tests cover:
+- Default construction and derived-attribute values
+- pixels_per_frame, frame_bytes and coadd_bytes calculations
+- single_frame_time (exposure plus read time)
+- Science vs imaging byte-per-pixel selection (is_vissci)
+- dropped_integration_time
+- solve_integrations frame counting and coadd flooring
+- solve_duration frame-count inversion
+- Roundtrip consistency between solve_integrations and solve_duration
+- Edge cases: zero ROI, zero duration, zero frame time
+"""
+
+# Third-party
+import pytest
+from astropy import units as u
+
+# First-party/Local
+from shortschedule.data.visda import VisdaData
+
+# ---------------------------------------------------------------------------
+# Shared test fixture — small, round-number parameters for easy hand calculation
+#
+# roi_dimension=4, num_rois=2
+# pixels_per_frame = 4**2 * 2 = 32
+#
+# is_vissci=True, vissci_bytes_per_pixel=4 byte
+# frame_bytes = 32 * 4 = 128 byte
+# coadd_bytes = 128 * 5 = 640 byte
+#
+# exposure_time_s=0.1 s, read_time_per_frame_s=0 s
+# single_frame_time = 0.1 s
+# ---------------------------------------------------------------------------
+
+_SIMPLE = dict(
+    frames_per_coadd=5,
+    roi_dimension=4,
+    num_rois=2,
+    exposure_time_s=0.1 * u.s,
+    is_vissci=True,
+    compression_ratio=0.5,
+    vissci_bytes_per_pixel=4 * u.byte,
+    visimg_bytes_per_pixel=2 * u.byte,
+    read_time_per_frame_s=0.0 * u.s,
+    additional_overhead_time=0 * u.s,
+    dropped_frames=0,
+)
+
+# Individual fixture fields, pulled out so the derived constants and the
+# assertions below all track _SIMPLE automatically when it is edited.
+_ROI_DIM = _SIMPLE['roi_dimension']
+_NUM_ROIS = _SIMPLE['num_rois']
+_COADD = _SIMPLE['frames_per_coadd']
+_VISSCI_BPP = _SIMPLE['vissci_bytes_per_pixel'].to_value(u.byte)
+_VISIMG_BPP = _SIMPLE['visimg_bytes_per_pixel'].to_value(u.byte)
+_EXPOSURE = _SIMPLE['exposure_time_s'].to_value(u.s)
+_READ_TIME = _SIMPLE['read_time_per_frame_s'].to_value(u.s)
+_COMP = _SIMPLE['compression_ratio']
+
+# Derived quantities (plain floats in SI units) computed straight from the
+# fixture, mirroring VisdaData._update_derived so the maths lives in one place.
+_PIXELS = _ROI_DIM**2 * _NUM_ROIS
+_FRAME_BYTES = _PIXELS * _VISSCI_BPP
+_COADD_BYTES = _FRAME_BYTES * _COADD
+_SFT = _EXPOSURE + _READ_TIME
+
+
+def _make(**overrides):
+    """Return a VisdaData built from _SIMPLE with optional field overrides."""
+    kwargs = {**_SIMPLE, **overrides}
+    return VisdaData(**kwargs)
+
+
+# ---------------------------------------------------------------------------
+# Default construction
+# ---------------------------------------------------------------------------
+class TestVisdaDataDefaults:
+    """VisdaData() with library defaults should produce sensible derived values."""
+
+    def test_default_construction_succeeds(self):
+        """VisdaData with all defaults should not raise."""
+        vd = VisdaData()
+        assert vd is not None
+
+    def test_default_pixels_per_frame(self):
+        """Default pixels_per_frame should match roi_dimension**2 * num_rois."""
+        vd = VisdaData()
+        assert vd.pixels_per_frame == vd.roi_dimension**2 * vd.num_rois
+
+    def test_default_frame_bytes_positive(self):
+        """Default frame_bytes should be a positive Quantity in bytes."""
+        vd = VisdaData()
+        assert vd.frame_bytes.to(u.byte).value > 0
+
+    def test_default_single_frame_time_positive(self):
+        """Default single_frame_time should be a positive Quantity in seconds."""
+        vd = VisdaData()
+        assert vd.single_frame_time.to(u.s).value > 0
+
+    def test_default_coadd_bytes_is_frame_bytes_times_coadds(self):
+        """coadd_bytes should equal frame_bytes * frames_per_coadd."""
+        vd = VisdaData()
+        expected = vd.frame_bytes * vd.frames_per_coadd
+        assert vd.coadd_bytes == expected
+
+
+# ---------------------------------------------------------------------------
+# pixels_per_frame
+# ---------------------------------------------------------------------------
+class TestPixelsPerFrame:
+    """Tests for the pixels_per_frame derived attribute."""
+
+    def test_value(self):
+        """pixels_per_frame should equal roi_dimension**2 * num_rois."""
+        vd = _make()
+        assert vd.pixels_per_frame == _PIXELS
+
+    def test_scales_with_num_rois(self):
+        """Doubling num_rois should double pixels_per_frame."""
+        vd_1 = _make(num_rois=1)
+        vd_2 = _make(num_rois=2)
+        assert vd_2.pixels_per_frame == 2 * vd_1.pixels_per_frame
+
+    def test_scales_with_dimension_squared(self):
+        """pixels_per_frame scales with the square of roi_dimension."""
+        vd_2 = _make(roi_dimension=2)
+        vd_4 = _make(roi_dimension=4)
+        assert vd_4.pixels_per_frame == 4 * vd_2.pixels_per_frame
+
+    def test_zero_dimension_gives_zero(self):
+        """A zero ROI dimension should yield zero pixels per frame."""
+        vd = _make(roi_dimension=0)
+        assert vd.pixels_per_frame == 0
+
+
+# ---------------------------------------------------------------------------
+# frame_bytes / coadd_bytes
+# ---------------------------------------------------------------------------
+class TestFrameBytes:
+    """Tests for frame_bytes and coadd_bytes derived attributes."""
+
+    def test_vissci_frame_bytes(self):
+        """Science mode uses vissci_bytes_per_pixel."""
+        vd = _make(is_vissci=True)
+        assert abs(vd.frame_bytes.to(u.byte).value - _FRAME_BYTES) < 1e-10
+
+    def test_visimg_frame_bytes(self):
+        """Imaging mode uses visimg_bytes_per_pixel."""
+        vd = _make(is_vissci=False)
+        expected = _PIXELS * _VISIMG_BPP
+        assert abs(vd.frame_bytes.to(u.byte).value - expected) < 1e-10
+
+    def test_coadd_bytes_value(self):
+        """coadd_bytes should equal frame_bytes * frames_per_coadd."""
+        vd = _make()
+        assert abs(vd.coadd_bytes.to(u.byte).value - _COADD_BYTES) < 1e-10
+
+    def test_frame_bytes_scales_with_bytes_per_pixel(self):
+        """Doubling vissci_bytes_per_pixel should double frame_bytes."""
+        vd_4 = _make(vissci_bytes_per_pixel=4 * u.byte)
+        vd_8 = _make(vissci_bytes_per_pixel=8 * u.byte)
+        assert abs(
+            vd_8.frame_bytes.to(u.byte).value - 2 * vd_4.frame_bytes.to(u.byte).value
+        ) < 1e-10
+
+    def test_zero_roi_gives_zero_frame_bytes(self):
+        """A zero ROI dimension should give zero frame bytes."""
+        vd = _make(roi_dimension=0)
+        assert vd.frame_bytes.to(u.byte).value == 0
+
+
+# ---------------------------------------------------------------------------
+# single_frame_time
+# ---------------------------------------------------------------------------
+class TestSingleFrameTime:
+    """Tests for the single_frame_time derived attribute."""
+
+    def test_value(self):
+        """single_frame_time should equal exposure_time_s + read_time_per_frame_s."""
+        vd = _make()
+        assert abs(vd.single_frame_time.to(u.s).value - _SFT) < 1e-15
+
+    def test_read_time_is_added(self):
+        """A non-zero read time should lengthen the frame time."""
+        vd_no_read = _make(read_time_per_frame_s=0.0 * u.s)
+        vd_read = _make(read_time_per_frame_s=0.05 * u.s)
+        assert abs(
+            vd_read.single_frame_time.to(u.s).value
+            - vd_no_read.single_frame_time.to(u.s).value
+            - 0.05
+        ) < 1e-12
+
+    def test_units_are_seconds(self):
+        """single_frame_time should be convertible to seconds."""
+        vd = _make()
+        _ = vd.single_frame_time.to(u.s)  # should not raise
+
+
+# ---------------------------------------------------------------------------
+# dropped_integration_time
+# ---------------------------------------------------------------------------
+class TestDroppedIntegrationTime:
+    """Tests for dropped_integration_time."""
+
+    def test_zero_dropped_frames(self):
+        """No dropped frames should give zero dropped_integration_time."""
+        vd = _make(dropped_frames=0)
+        assert vd.dropped_integration_time.to(u.s).value == 0
+
+    def test_dropped_integration_time_value(self):
+        """dropped_integration_time should equal dropped_frames * single_frame_time."""
+        vd = _make(dropped_frames=3)
+        assert abs(vd.dropped_integration_time.to(u.s).value - 3 * _SFT) < 1e-12
+
+
+# ---------------------------------------------------------------------------
+# solve_integrations
+# ---------------------------------------------------------------------------
+class TestSolveIntegrations:
+    """Tests for solve_integrations(duration, pre_overhead, post_overhead)."""
+
+    def test_returns_three_tuple(self):
+        """solve_integrations should return (frames, data, data_compressed)."""
+        vd = _make()
+        result = vd.solve_integrations(10.0 * u.s)
+        assert len(result) == 3
+
+    def test_frames_is_int(self):
+        """Frame count should be an integer."""
+        vd = _make()
+        frames, _, _ = vd.solve_integrations(10.0 * u.s)
+        assert isinstance(frames, int)
+
+    def test_zero_duration_yields_zero_frames(self):
+        """A zero-length window should produce no frames."""
+        vd = _make()
+        frames, data, data_c = vd.solve_integrations(0.0 * u.s, 0 * u.s, 0 * u.s)
+        assert frames == 0
+        assert data.to(u.byte).value == 0
+        assert data_c.to(u.byte).value == 0
+
+    def test_frames_floored_to_coadd_multiple(self):
+        """Frame count should be floored to a whole number of coadds."""
+        vd = _make()
+        # Seven frames' worth of time, plus a tiny guard, must floor to 5.
+        duration = vd.single_frame_time * 7 * (1 + 1e-9)
+        frames, _, _ = vd.solve_integrations(duration, 0 * u.s, 0 * u.s)
+        assert frames == 5
+
+    def test_exact_coadd_window(self):
+        """Time for exactly one coadd should give frames_per_coadd frames."""
+        vd = _make()
+        duration = vd.single_frame_time * _COADD * (1 + 1e-9)
+        frames, _, _ = vd.solve_integrations(duration, 0 * u.s, 0 * u.s)
+        assert frames == _COADD
+
+    def test_frames_always_multiple_of_coadd(self):
+        """Whatever the window, frames is a multiple of frames_per_coadd."""
+        vd = _make()
+        for n in range(1, 40):
+            duration = vd.single_frame_time * n * (1 + 1e-9)
+            frames, _, _ = vd.solve_integrations(duration, 0 * u.s, 0 * u.s)
+            assert frames % _COADD == 0
+
+    def test_overhead_reduces_frames(self):
+        """Adding overhead should reduce the number of frames."""
+        vd = _make()
+        duration = vd.single_frame_time * 20
+        n_no_oh, _, _ = vd.solve_integrations(duration, 0 * u.s, 0 * u.s)
+        n_with_oh, _, _ = vd.solve_integrations(
+            duration, vd.single_frame_time * 10, 0 * u.s
+        )
+        assert n_with_oh < n_no_oh
+
+    def test_additional_overhead_reduces_frames(self):
+        """additional_overhead_time should reduce the effective window."""
+        vd_no_oh = _make(additional_overhead_time=0 * u.s)
+        vd_with_oh = _make(additional_overhead_time=_SFT * 10 * u.s)
+        duration = _make().single_frame_time * 20
+        n_no, _, _ = vd_no_oh.solve_integrations(duration, 0 * u.s, 0 * u.s)
+        n_with, _, _ = vd_with_oh.solve_integrations(duration, 0 * u.s, 0 * u.s)
+        assert n_with < n_no
+
+    def test_data_scales_with_frames(self):
+        """data should equal frames * frame_bytes."""
+        vd = _make()
+        frames, data, _ = vd.solve_integrations(
+            vd.single_frame_time * 20, 0 * u.s, 0 * u.s
+        )
+        expected = frames * vd.frame_bytes
+        assert abs(data.to(u.byte).value - expected.to(u.byte).value) < 1e-6
+
+    def test_compressed_data_uses_compression_ratio(self):
+        """data_compressed should equal data * compression_ratio."""
+        vd = _make(compression_ratio=0.5)
+        _, data, data_c = vd.solve_integrations(
+            vd.single_frame_time * 20, 0 * u.s, 0 * u.s
+        )
+        assert abs(data_c.to(u.byte).value - 0.5 * data.to(u.byte).value) < 1e-6
+
+    def test_duration_shorter_than_one_coadd_gives_zero(self):
+        """If less than one coadd fits, frame count should be zero."""
+        vd = _make()
+        duration = vd.single_frame_time * (_COADD - 1)
+        frames, _, _ = vd.solve_integrations(duration, 0 * u.s, 0 * u.s)
+        assert frames == 0
+
+    def test_zero_frame_time_gives_zero_frames(self):
+        """Zero single_frame_time must not divide by zero; it yields zero frames."""
+        vd = _make(exposure_time_s=0.0 * u.s, read_time_per_frame_s=0.0 * u.s)
+        assert vd.single_frame_time.to(u.s).value == 0
+        frames, _, _ = vd.solve_integrations(100.0 * u.s, 0 * u.s, 0 * u.s)
+        assert frames == 0
+
+    def test_zero_frames_per_coadd_does_not_raise(self):
+        """frames_per_coadd of zero must not trigger a modulo-by-zero error."""
+        vd = _make(frames_per_coadd=0)
+        frames, _, _ = vd.solve_integrations(
+            vd.single_frame_time * 7, 0 * u.s, 0 * u.s
+        )
+        assert frames >= 0
+
+
+# ---------------------------------------------------------------------------
+# solve_duration
+# ---------------------------------------------------------------------------
+class TestSolveDuration:
+    """Tests for solve_duration(integrations, pre_overhead, post_overhead)."""
+
+    def test_returns_three_tuple(self):
+        """solve_duration should return (duration, data, data_compressed)."""
+        vd = _make()
+        result = vd.solve_duration(5)
+        assert len(result) == 3
+
+    def test_zero_integrations_returns_zero_duration(self):
+        """Requesting zero frames should give zero duration and zero data."""
+        vd = _make()
+        duration, data, data_c = vd.solve_duration(0)
+        assert duration.to(u.s).value == 0.0
+        assert data.to(u.byte).value == 0.0
+        assert data_c.to(u.byte).value == 0.0
+
+    def test_negative_integrations_treated_as_zero(self):
+        """Negative frame counts should be treated as zero."""
+        vd = _make()
+        duration, data, _ = vd.solve_duration(-5)
+        assert duration.to(u.s).value == 0.0
+        assert data.to(u.byte).value == 0.0
+
+    def test_duration_value(self):
+        """duration = integrations * single_frame_time + overheads."""
+        vd = _make()
+        duration, _, _ = vd.solve_duration(10, 0 * u.s, 0 * u.s)
+        assert abs(duration.to(u.s).value - 10 * _SFT) < 1e-12
+
+    def test_overhead_added_to_duration(self):
+        """Overhead parameters should be added to the total duration."""
+        vd = _make()
+        pre, post = 30.0 * u.s, 10.0 * u.s
+        dur_no_oh, _, _ = vd.solve_duration(3, 0 * u.s, 0 * u.s)
+        dur_with_oh, _, _ = vd.solve_duration(3, pre, post)
+        assert abs(
+            dur_with_oh.to(u.s).value - dur_no_oh.to(u.s).value - 40.0
+        ) < 1e-12
+
+    def test_data_is_pure_bytes(self):
+        """data should be a plain byte Quantity, not byte*second."""
+        vd = _make()
+        _, data, _ = vd.solve_duration(10, 0 * u.s, 0 * u.s)
+        # Convertible to bytes without a leftover time dimension.
+        assert data.unit.is_equivalent(u.byte)
+
+    def test_data_scales_with_integrations(self):
+        """data should equal integrations * frame_bytes."""
+        vd = _make()
+        n = 7
+        _, data, _ = vd.solve_duration(n, 0 * u.s, 0 * u.s)
+        expected = n * vd.frame_bytes.to(u.byte).value
+        assert abs(data.to(u.byte).value - expected) < 1e-6
+
+    def test_compressed_data_uses_compression_ratio(self):
+        """data_compressed should equal data * compression_ratio."""
+        vd = _make(compression_ratio=0.25)
+        _, data, data_c = vd.solve_duration(8, 0 * u.s, 0 * u.s)
+        assert abs(data_c.to(u.byte).value - 0.25 * data.to(u.byte).value) < 1e-6
+
+    def test_additional_overhead_added_to_duration(self):
+        """solve_duration should add additional_overhead_time to the total."""
+        vd_no_oh = _make(additional_overhead_time=0 * u.s)
+        vd_with_oh = _make(additional_overhead_time=5.0 * u.s)
+        dur_no, _, _ = vd_no_oh.solve_duration(3, 0 * u.s, 0 * u.s)
+        dur_with, _, _ = vd_with_oh.solve_duration(3, 0 * u.s, 0 * u.s)
+        assert abs(dur_with.to(u.s).value - dur_no.to(u.s).value - 5.0) < 1e-12
+
+    def test_additional_overhead_not_added_when_zero_integrations(self):
+        """Zero frames should give zero duration regardless of overhead."""
+        vd = _make(additional_overhead_time=5.0 * u.s)
+        duration, _, _ = vd.solve_duration(0, 0 * u.s, 0 * u.s)
+        assert duration.to(u.s).value == 0.0
+
+    def test_duration_increases_monotonically(self):
+        """More frames should always require more time."""
+        vd = _make()
+        durations = [
+            vd.solve_duration(n, 0 * u.s, 0 * u.s)[0].to(u.s).value
+            for n in range(1, 6)
+        ]
+        for i in range(len(durations) - 1):
+            assert durations[i + 1] > durations[i]
+
+
+# ---------------------------------------------------------------------------
+# Roundtrip: solve_duration ↔ solve_integrations
+# ---------------------------------------------------------------------------
+class TestSolveRoundtrip:
+    """solve_integrations(solve_duration(n)) should recover n for coadd multiples."""
+
+    def test_roundtrip_no_overhead(self):
+        """With no overhead, a coadd-multiple frame count should round-trip."""
+        vd = _make()
+        for n in (_COADD, 2 * _COADD, 3 * _COADD):
+            duration, _, _ = vd.solve_duration(n, 0 * u.s, 0 * u.s)
+            # Tiny relative guard against floating-point loss when re-dividing.
+            duration = duration + vd.single_frame_time * 1e-6
+            recovered, _, _ = vd.solve_integrations(duration, 0 * u.s, 0 * u.s)
+            assert recovered == n, f"Roundtrip failed for n={n}: recovered {recovered}"
+
+    def test_roundtrip_with_overhead(self):
+        """Roundtrip should hold when consistent overhead is used in both calls."""
+        vd = _make()
+        pre, post = 20.0 * u.s, 10.0 * u.s
+        for n in (_COADD, 2 * _COADD):
+            duration, _, _ = vd.solve_duration(n, pre, post)
+            duration = duration + vd.single_frame_time * 1e-6
+            recovered, _, _ = vd.solve_integrations(duration, pre, post)
+            assert recovered == n, (
+                f"Roundtrip with overhead failed for n={n}: recovered {recovered}"
+            )
+
+
+# ---------------------------------------------------------------------------
+# Science vs imaging mode
+# ---------------------------------------------------------------------------
+class TestVissciVsVisimg:
+    """is_vissci selects the bytes-per-pixel and therefore the data volume."""
+
+    def test_science_uses_more_bytes_than_imaging(self):
+        """With vissci_bpp > visimg_bpp, science mode produces more data."""
+        vd_sci = _make(is_vissci=True)
+        vd_img = _make(is_vissci=False)
+        assert vd_sci.frame_bytes > vd_img.frame_bytes
+
+    def test_mode_does_not_change_timing(self):
+        """Switching mode must not change frame timing."""
+        vd_sci = _make(is_vissci=True)
+        vd_img = _make(is_vissci=False)
+        assert vd_sci.single_frame_time == vd_img.single_frame_time
+        assert vd_sci.pixels_per_frame == vd_img.pixels_per_frame

--- a/tests/test_visda.py
+++ b/tests/test_visda.py
@@ -309,6 +309,30 @@ class TestSolveIntegrations:
         )
         assert abs(data_c.to(u.byte).value - 0.5 * data.to(u.byte).value) < 1e-6
 
+    def test_subsecond_noise_does_not_drop_a_coadd(self):
+        """A duration a sub-microsecond below an exact frame boundary must
+        floor to the same count, not lose a whole coadd.
+
+        Regression: astropy ``Time`` subtraction (e.g. a merged sequence's
+        duration) carries sub-microsecond float noise that varies with the
+        absolute epoch. With exposure 0.2 s and 260/102 s overheads a 2640 s
+        observation fits exactly 11390 frames (a multiple of 5). Noise that
+        nudges the duration to 2639.9999995 s must not floor the count to
+        11389 and then drop to 11385 via the coadd-multiple flooring.
+        """
+        vd = _make(
+            exposure_time_s=0.2 * u.s,
+            read_time_per_frame_s=0.0 * u.s,
+            frames_per_coadd=5,
+        )
+        overhead = _visda_overhead(pre=260 * u.s, post=102 * u.s)
+
+        n_exact, _, _ = vd.solve_integrations(2640.0 * u.s, overhead)
+        n_noisy, _, _ = vd.solve_integrations((2640.0 - 5e-7) * u.s, overhead)
+
+        assert n_exact == 11390
+        assert n_noisy == n_exact
+
     def test_duration_shorter_than_one_coadd_gives_zero(self):
         """If less than one coadd fits, frame count should be zero."""
         vd = _make()

--- a/tests/test_visda.py
+++ b/tests/test_visda.py
@@ -17,7 +17,16 @@ import pytest
 from astropy import units as u
 
 # First-party/Local
+from shortschedule.overhead import OverheadTiming
 from shortschedule.visda import VisdaData
+
+
+def _visda_overhead(pre=0 * u.s, post=0 * u.s):
+    """OverheadTiming carrying only the VISDA pre/post overheads under test."""
+    return OverheadTiming(
+        visda_pre_overhead_time=pre,
+        visda_post_overhead_time=post,
+    )
 
 # ---------------------------------------------------------------------------
 # Shared test fixture — small, round-number parameters for easy hand calculation
@@ -235,7 +244,7 @@ class TestSolveIntegrations:
     def test_zero_duration_yields_zero_frames(self):
         """A zero-length window should produce no frames."""
         vd = _make()
-        frames, data, data_c = vd.solve_integrations(0.0 * u.s, 0 * u.s, 0 * u.s)
+        frames, data, data_c = vd.solve_integrations(0.0 * u.s, _visda_overhead())
         assert frames == 0
         assert data.to(u.byte).value == 0
         assert data_c.to(u.byte).value == 0
@@ -245,14 +254,14 @@ class TestSolveIntegrations:
         vd = _make()
         # Seven frames' worth of time, plus a tiny guard, must floor to 5.
         duration = vd.single_frame_time * 7 * (1 + 1e-9)
-        frames, _, _ = vd.solve_integrations(duration, 0 * u.s, 0 * u.s)
+        frames, _, _ = vd.solve_integrations(duration, _visda_overhead())
         assert frames == 5
 
     def test_exact_coadd_window(self):
         """Time for exactly one coadd should give frames_per_coadd frames."""
         vd = _make()
         duration = vd.single_frame_time * _COADD * (1 + 1e-9)
-        frames, _, _ = vd.solve_integrations(duration, 0 * u.s, 0 * u.s)
+        frames, _, _ = vd.solve_integrations(duration, _visda_overhead())
         assert frames == _COADD
 
     def test_frames_always_multiple_of_coadd(self):
@@ -260,16 +269,16 @@ class TestSolveIntegrations:
         vd = _make()
         for n in range(1, 40):
             duration = vd.single_frame_time * n * (1 + 1e-9)
-            frames, _, _ = vd.solve_integrations(duration, 0 * u.s, 0 * u.s)
+            frames, _, _ = vd.solve_integrations(duration, _visda_overhead())
             assert frames % _COADD == 0
 
     def test_overhead_reduces_frames(self):
         """Adding overhead should reduce the number of frames."""
         vd = _make()
         duration = vd.single_frame_time * 20
-        n_no_oh, _, _ = vd.solve_integrations(duration, 0 * u.s, 0 * u.s)
+        n_no_oh, _, _ = vd.solve_integrations(duration, _visda_overhead())
         n_with_oh, _, _ = vd.solve_integrations(
-            duration, vd.single_frame_time * 10, 0 * u.s
+            duration, _visda_overhead(vd.single_frame_time * 10)
         )
         assert n_with_oh < n_no_oh
 
@@ -278,15 +287,15 @@ class TestSolveIntegrations:
         vd_no_oh = _make(additional_overhead_time=0 * u.s)
         vd_with_oh = _make(additional_overhead_time=_SFT * 10 * u.s)
         duration = _make().single_frame_time * 20
-        n_no, _, _ = vd_no_oh.solve_integrations(duration, 0 * u.s, 0 * u.s)
-        n_with, _, _ = vd_with_oh.solve_integrations(duration, 0 * u.s, 0 * u.s)
+        n_no, _, _ = vd_no_oh.solve_integrations(duration, _visda_overhead())
+        n_with, _, _ = vd_with_oh.solve_integrations(duration, _visda_overhead())
         assert n_with < n_no
 
     def test_data_scales_with_frames(self):
         """data should equal frames * frame_bytes."""
         vd = _make()
         frames, data, _ = vd.solve_integrations(
-            vd.single_frame_time * 20, 0 * u.s, 0 * u.s
+            vd.single_frame_time * 20, _visda_overhead()
         )
         expected = frames * vd.frame_bytes
         assert abs(data.to(u.byte).value - expected.to(u.byte).value) < 1e-6
@@ -295,7 +304,7 @@ class TestSolveIntegrations:
         """data_compressed should equal data * compression_ratio."""
         vd = _make(compression_ratio=0.5)
         _, data, data_c = vd.solve_integrations(
-            vd.single_frame_time * 20, 0 * u.s, 0 * u.s
+            vd.single_frame_time * 20, _visda_overhead()
         )
         assert abs(data_c.to(u.byte).value - 0.5 * data.to(u.byte).value) < 1e-6
 
@@ -303,21 +312,21 @@ class TestSolveIntegrations:
         """If less than one coadd fits, frame count should be zero."""
         vd = _make()
         duration = vd.single_frame_time * (_COADD - 1)
-        frames, _, _ = vd.solve_integrations(duration, 0 * u.s, 0 * u.s)
+        frames, _, _ = vd.solve_integrations(duration, _visda_overhead())
         assert frames == 0
 
     def test_zero_frame_time_gives_zero_frames(self):
         """Zero single_frame_time must not divide by zero; it yields zero frames."""
         vd = _make(exposure_time_s=0.0 * u.s, read_time_per_frame_s=0.0 * u.s)
         assert vd.single_frame_time.to(u.s).value == 0
-        frames, _, _ = vd.solve_integrations(100.0 * u.s, 0 * u.s, 0 * u.s)
+        frames, _, _ = vd.solve_integrations(100.0 * u.s, _visda_overhead())
         assert frames == 0
 
     def test_zero_frames_per_coadd_does_not_raise(self):
         """frames_per_coadd of zero must not trigger a modulo-by-zero error."""
         vd = _make(frames_per_coadd=0)
         frames, _, _ = vd.solve_integrations(
-            vd.single_frame_time * 7, 0 * u.s, 0 * u.s
+            vd.single_frame_time * 7, _visda_overhead()
         )
         assert frames >= 0
 
@@ -352,15 +361,15 @@ class TestSolveDuration:
     def test_duration_value(self):
         """duration = integrations * single_frame_time + overheads."""
         vd = _make()
-        duration, _, _ = vd.solve_duration(10, 0 * u.s, 0 * u.s)
+        duration, _, _ = vd.solve_duration(10, _visda_overhead())
         assert abs(duration.to(u.s).value - 10 * _SFT) < 1e-12
 
     def test_overhead_added_to_duration(self):
         """Overhead parameters should be added to the total duration."""
         vd = _make()
         pre, post = 30.0 * u.s, 10.0 * u.s
-        dur_no_oh, _, _ = vd.solve_duration(3, 0 * u.s, 0 * u.s)
-        dur_with_oh, _, _ = vd.solve_duration(3, pre, post)
+        dur_no_oh, _, _ = vd.solve_duration(3, _visda_overhead())
+        dur_with_oh, _, _ = vd.solve_duration(3, _visda_overhead(pre, post))
         assert abs(
             dur_with_oh.to(u.s).value - dur_no_oh.to(u.s).value - 40.0
         ) < 1e-12
@@ -368,7 +377,7 @@ class TestSolveDuration:
     def test_data_is_pure_bytes(self):
         """data should be a plain byte Quantity, not byte*second."""
         vd = _make()
-        _, data, _ = vd.solve_duration(10, 0 * u.s, 0 * u.s)
+        _, data, _ = vd.solve_duration(10, _visda_overhead())
         # Convertible to bytes without a leftover time dimension.
         assert data.unit.is_equivalent(u.byte)
 
@@ -376,35 +385,35 @@ class TestSolveDuration:
         """data should equal integrations * frame_bytes."""
         vd = _make()
         n = 7
-        _, data, _ = vd.solve_duration(n, 0 * u.s, 0 * u.s)
+        _, data, _ = vd.solve_duration(n, _visda_overhead())
         expected = n * vd.frame_bytes.to(u.byte).value
         assert abs(data.to(u.byte).value - expected) < 1e-6
 
     def test_compressed_data_uses_compression_ratio(self):
         """data_compressed should equal data * compression_ratio."""
         vd = _make(compression_ratio=0.25)
-        _, data, data_c = vd.solve_duration(8, 0 * u.s, 0 * u.s)
+        _, data, data_c = vd.solve_duration(8, _visda_overhead())
         assert abs(data_c.to(u.byte).value - 0.25 * data.to(u.byte).value) < 1e-6
 
     def test_additional_overhead_added_to_duration(self):
         """solve_duration should add additional_overhead_time to the total."""
         vd_no_oh = _make(additional_overhead_time=0 * u.s)
         vd_with_oh = _make(additional_overhead_time=5.0 * u.s)
-        dur_no, _, _ = vd_no_oh.solve_duration(3, 0 * u.s, 0 * u.s)
-        dur_with, _, _ = vd_with_oh.solve_duration(3, 0 * u.s, 0 * u.s)
+        dur_no, _, _ = vd_no_oh.solve_duration(3, _visda_overhead())
+        dur_with, _, _ = vd_with_oh.solve_duration(3, _visda_overhead())
         assert abs(dur_with.to(u.s).value - dur_no.to(u.s).value - 5.0) < 1e-12
 
     def test_additional_overhead_not_added_when_zero_integrations(self):
         """Zero frames should give zero duration regardless of overhead."""
         vd = _make(additional_overhead_time=5.0 * u.s)
-        duration, _, _ = vd.solve_duration(0, 0 * u.s, 0 * u.s)
+        duration, _, _ = vd.solve_duration(0, _visda_overhead())
         assert duration.to(u.s).value == 0.0
 
     def test_duration_increases_monotonically(self):
         """More frames should always require more time."""
         vd = _make()
         durations = [
-            vd.solve_duration(n, 0 * u.s, 0 * u.s)[0].to(u.s).value
+            vd.solve_duration(n, _visda_overhead())[0].to(u.s).value
             for n in range(1, 6)
         ]
         for i in range(len(durations) - 1):
@@ -421,10 +430,10 @@ class TestSolveRoundtrip:
         """With no overhead, a coadd-multiple frame count should round-trip."""
         vd = _make()
         for n in (_COADD, 2 * _COADD, 3 * _COADD):
-            duration, _, _ = vd.solve_duration(n, 0 * u.s, 0 * u.s)
+            duration, _, _ = vd.solve_duration(n, _visda_overhead())
             # Tiny relative guard against floating-point loss when re-dividing.
             duration = duration + vd.single_frame_time * 1e-6
-            recovered, _, _ = vd.solve_integrations(duration, 0 * u.s, 0 * u.s)
+            recovered, _, _ = vd.solve_integrations(duration, _visda_overhead())
             assert recovered == n, f"Roundtrip failed for n={n}: recovered {recovered}"
 
     def test_roundtrip_with_overhead(self):
@@ -432,9 +441,9 @@ class TestSolveRoundtrip:
         vd = _make()
         pre, post = 20.0 * u.s, 10.0 * u.s
         for n in (_COADD, 2 * _COADD):
-            duration, _, _ = vd.solve_duration(n, pre, post)
+            duration, _, _ = vd.solve_duration(n, _visda_overhead(pre, post))
             duration = duration + vd.single_frame_time * 1e-6
-            recovered, _, _ = vd.solve_integrations(duration, pre, post)
+            recovered, _, _ = vd.solve_integrations(duration, _visda_overhead(pre, post))
             assert recovered == n, (
                 f"Roundtrip with overhead failed for n={n}: recovered {recovered}"
             )

--- a/tests/test_visda.py
+++ b/tests/test_visda.py
@@ -458,3 +458,45 @@ class TestVissciVsVisimg:
         vd_img = _make(is_vissci=False)
         assert vd_sci.single_frame_time == vd_img.single_frame_time
         assert vd_sci.pixels_per_frame == vd_img.pixels_per_frame
+
+
+# ---------------------------------------------------------------------------
+# Payload config spec / get_config
+# ---------------------------------------------------------------------------
+class TestVisdaConfigSpec:
+    """Tests for the payload config mapping and get_config()."""
+
+    def test_get_config_keys_match_spec(self):
+        """get_config returns exactly the CONFIG_SPEC field names."""
+        vd = VisdaData()
+        assert set(vd.get_config().keys()) == set(VisdaData.CONFIG_SPEC.keys())
+
+    def test_get_config_returns_current_values(self):
+        """get_config reflects this instance's field values."""
+        vd = _make(frames_per_coadd=3, num_rois=4)
+        cfg = vd.get_config()
+        assert cfg["frames_per_coadd"] == 3
+        assert cfg["num_rois"] == 4
+
+    def test_spec_fields_are_real_attributes(self):
+        """Every CONFIG_SPEC field is a real VisdaData attribute."""
+        vd = VisdaData()
+        for field_name in VisdaData.CONFIG_SPEC:
+            assert hasattr(vd, field_name)
+
+    def test_payload_section_is_vis_cam(self):
+        """VISDA config lives under the AcquireVisCamScienceData payload."""
+        assert VisdaData.PAYLOAD_SECTION == "AcquireVisCamScienceData"
+
+    def test_required_fields(self):
+        """Exposure and frames-per-coadd are required; ROI fields are not."""
+        assert "exposure_time_s" in VisdaData.REQUIRED_CONFIG_FIELDS
+        assert "frames_per_coadd" in VisdaData.REQUIRED_CONFIG_FIELDS
+        assert "roi_dimension" not in VisdaData.REQUIRED_CONFIG_FIELDS
+
+    def test_exposure_converters_microseconds(self):
+        """Exposure round-trips through the microsecond payload encoding."""
+        tag, from_xml, to_xml = VisdaData.CONFIG_SPEC["exposure_time_s"]
+        # 0.2 s default -> "200000" us -> 0.2 s
+        assert to_xml(0.2 * u.s) == "200000"
+        assert abs(from_xml("200000").to(u.s).value - 0.2) < 1e-9

--- a/tests/test_visda.py
+++ b/tests/test_visda.py
@@ -292,12 +292,13 @@ class TestSolveIntegrations:
         assert n_with < n_no
 
     def test_data_scales_with_frames(self):
-        """data should equal frames * frame_bytes."""
+        """data should equal coadds * frame_bytes (saved, net of coadding)."""
         vd = _make()
         frames, data, _ = vd.solve_integrations(
             vd.single_frame_time * 20, _visda_overhead()
         )
-        expected = frames * vd.frame_bytes
+        coadds = frames // vd.frames_per_coadd
+        expected = coadds * vd.frame_bytes
         assert abs(data.to(u.byte).value - expected.to(u.byte).value) < 1e-6
 
     def test_compressed_data_uses_compression_ratio(self):
@@ -382,11 +383,11 @@ class TestSolveDuration:
         assert data.unit.is_equivalent(u.byte)
 
     def test_data_scales_with_integrations(self):
-        """data should equal integrations * frame_bytes."""
+        """data should equal coadds * frame_bytes (saved, net of coadding)."""
         vd = _make()
-        n = 7
+        n = 35
         _, data, _ = vd.solve_duration(n, _visda_overhead())
-        expected = n * vd.frame_bytes.to(u.byte).value
+        expected = (n // vd.frames_per_coadd) * vd.frame_bytes.to(u.byte).value
         assert abs(data.to(u.byte).value - expected) < 1e-6
 
     def test_compressed_data_uses_compression_ratio(self):

--- a/tests/test_visda.py
+++ b/tests/test_visda.py
@@ -17,7 +17,7 @@ import pytest
 from astropy import units as u
 
 # First-party/Local
-from shortschedule.data.visda import VisdaData
+from shortschedule.visda import VisdaData
 
 # ---------------------------------------------------------------------------
 # Shared test fixture — small, round-number parameters for easy hand calculation


### PR DESCRIPTION
This adds all of the changes that have been done outside of the short-term calendar with separate cleaning scripts.

Please note if you are comparing the results with those from the cleaner you will need to make sure the cleaner script uses the following:
- You are using calendar cleaner v0.3.0
- Change the `vitl_settle_time_sec` from 60.5 to 60.0
- Change the `observation_buffer_min` from 0.1 to 0.0

There is a new helper script in the docs/ folder "run_scheduler_example.py" to quickly run a calendar based on a long-term xml and tles.

The changes to the short term scheduler are:

- Adds NIRDA and VISDA classes which contain accurate and up to date parameters to perform timing and data volume calculations.
- Adds overhead class which accounts for pre- and post- overhead timings for both VISDA and NIRDA.
- Adds baseline short-term calendar runner script to docs/
- Adds ability to merge back-to-back observations of the same target.
- Adds ability to override payload parameters set by original long-term calendar on a per-priority type basis.
  - Overrides can be taken from user provided dict or from the visda/nirda class defaults.
- Adds warnings if single NIRDA or VISDA data file exceeds payload limits.
- Adds dependence on NIRDA reset1 for VITL settling time. These parameters are all adjustable.
- Adds helper that renumbers both visits and sequencies to fix any misnumbering after merges.
- Adds log file to track changes, info, and warnings raised by the short term scheduler.
- Fixes minute-by-minute parsing to improve processing time.
- Adds several progress bars during various slower processing sections.
- Adds helper method to generate diagnostic data file.
  - Diag file contains a observation file manifest including compressed fits file names.
- Adds short term scheduler to processed calendar meta data.
- Adds override for PRI_CMD_DIR -> 9.
- Adds ability to convert det method 2 to 1 and adds pre-defined RA/DEC for the single ROI for observations that have max_num_rois = 1.
- Adds ability to clean bad symbols (like "+") and other unsupported words (like "nan").
- Adds data volume exploration jupyter notebook to docs/
- Adds tests for all of these changes.